### PR TITLE
feat: add pointer helpers

### DIFF
--- a/src/__tests__/jsonPointerToPath.ts
+++ b/src/__tests__/jsonPointerToPath.ts
@@ -1,0 +1,11 @@
+import { pointerToPath } from '../pointerToPath';
+
+test('pointerToPath', () => {
+  expect(pointerToPath('#/foo')).toEqual(['foo']);
+  expect(pointerToPath('#/foo/bar')).toEqual(['foo', 'bar']);
+  expect(pointerToPath('#/0')).toEqual(['0']);
+  expect(pointerToPath('#/paths/~1users')).toEqual(['paths', '/users']);
+  expect(pointerToPath('#/paths/foo~0users')).toEqual(['paths', 'foo~users']);
+  expect(pointerToPath('#')).toEqual([]);
+  expect(pointerToPath('#/')).toEqual(['']);
+});

--- a/src/__tests__/pathToJsonPointer.spec.ts
+++ b/src/__tests__/pathToJsonPointer.spec.ts
@@ -1,0 +1,11 @@
+import { pathToPointer } from '../pathToPointer';
+
+test('pathToPointer', () => {
+  expect(pathToPointer(['foo'])).toEqual('#/foo');
+  expect(pathToPointer(['foo', 'bar'])).toEqual('#/foo/bar');
+  expect(pathToPointer(['0'])).toEqual('#/0');
+  expect(pathToPointer(['paths', '/users'])).toEqual('#/paths/~1users');
+  expect(pathToPointer(['paths', 'foo~users'])).toEqual('#/paths/foo~0users');
+  expect(pathToPointer([])).toEqual('#');
+  expect(pathToPointer([''])).toEqual('#/');
+});

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Internal helper for now.
+ *
+ * At some point, if we have enough string helpers, this might go in a string repo? Or this repo becomes more generic utils.
+ */
+export const replaceInString = (str: string, find: string, repl: string): string => {
+  // modified from http://jsperf.com/javascript-replace-all/10
+  const orig = str.toString();
+  let res = '';
+  let rem = orig;
+  let beg = 0;
+  let end = rem.indexOf(find);
+
+  while (end > -1) {
+    res += orig.substring(beg, beg + end) + repl;
+    rem = rem.substring(end + find.length, rem.length);
+    beg += end + find.length;
+    end = rem.indexOf(find);
+  }
+
+  if (rem.length > 0) {
+    res += orig.substring(orig.length - rem.length, orig.length);
+  }
+
+  return res;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export * from './decycle';
+export * from './pathToPointer';
+export * from './pointerToPath';
 export * from './safeParse';
 export * from './safeStringify';
 export * from './startsWith';

--- a/src/pathToPointer.ts
+++ b/src/pathToPointer.ts
@@ -1,0 +1,29 @@
+import { replaceInString } from './_utils';
+
+export const pathToPointer = (path: string[]): string => {
+  return encodeUriFragmentIdentifier(path);
+};
+
+const encodeFragmentSegment = (segment: string): string => {
+  if (typeof segment === 'string') {
+    return replaceInString(replaceInString(segment, '~', '~0'), '/', '~1');
+  }
+
+  return segment;
+};
+
+const encodeFragmentSegments = (segments: string[]): string[] => {
+  return segments.map(encodeFragmentSegment);
+};
+
+const encodeUriFragmentIdentifier = (path: string[]): string => {
+  if (path && typeof path !== 'object') {
+    throw new TypeError('Invalid type: path must be an array of segments.');
+  }
+
+  if (path.length === 0) {
+    return '#';
+  }
+
+  return `#/${encodeFragmentSegments(path).join('/')}`;
+};

--- a/src/pointerToPath.ts
+++ b/src/pointerToPath.ts
@@ -1,0 +1,37 @@
+import { replaceInString } from './_utils';
+
+export const pointerToPath = (pointer: string): string[] => {
+  return decodeUriFragmentIdentifier(pointer);
+};
+
+const decodeFragmentSegments = (segments: string[]): string[] => {
+  const len = segments.length;
+  const res = new Array(len);
+  let i = -1;
+
+  while (++i < len) {
+    res[i] = replaceInString(replaceInString(decodeURIComponent('' + segments[i]), '~1', '/'), '~0', '~');
+  }
+
+  return res;
+};
+
+const decodeUriFragmentIdentifier = (ptr: string): string[] => {
+  if (typeof ptr !== 'string') {
+    throw new TypeError('Invalid type: JSON Pointers are represented as strings.');
+  }
+
+  if (ptr.length === 0 || ptr[0] !== '#') {
+    throw new ReferenceError('Invalid JSON Pointer syntax; URI fragment idetifiers must begin with a hash.');
+  }
+
+  if (ptr.length === 1) {
+    return [];
+  }
+
+  if (ptr[1] !== '/') {
+    throw new ReferenceError('Invalid JSON Pointer syntax.');
+  }
+
+  return decodeFragmentSegments(ptr.substring(2).split('/'));
+};

--- a/src/pointerToPath.ts
+++ b/src/pointerToPath.ts
@@ -6,11 +6,11 @@ export const pointerToPath = (pointer: string): string[] => {
 
 const decodeFragmentSegments = (segments: string[]): string[] => {
   const len = segments.length;
-  const res = new Array(len);
+  const res = [];
   let i = -1;
 
   while (++i < len) {
-    res[i] = replaceInString(replaceInString(decodeURIComponent('' + segments[i]), '~1', '/'), '~0', '~');
+    res.push(replaceInString(replaceInString(decodeURIComponent('' + segments[i]), '~1', '/'), '~0', '~'));
   }
 
   return res;

--- a/src/pointerToPath.ts
+++ b/src/pointerToPath.ts
@@ -22,7 +22,7 @@ const decodeUriFragmentIdentifier = (ptr: string): string[] => {
   }
 
   if (ptr.length === 0 || ptr[0] !== '#') {
-    throw new ReferenceError('Invalid JSON Pointer syntax; URI fragment idetifiers must begin with a hash.');
+    throw new URIError('Invalid JSON Pointer syntax; URI fragment idetifiers must begin with a hash.');
   }
 
   if (ptr.length === 1) {
@@ -30,7 +30,7 @@ const decodeUriFragmentIdentifier = (ptr: string): string[] => {
   }
 
   if (ptr[1] !== '/') {
-    throw new ReferenceError('Invalid JSON Pointer syntax.');
+    throw new URIError('Invalid JSON Pointer syntax.');
   }
 
   return decodeFragmentSegments(ptr.substring(2).split('/'));


### PR DESCRIPTION
These are extracted and cleaned up from the json-ref-parser repo. The are generically applicable to everywhere we want to work with json pointers (graph, ui-tree, studio, etc).

@P0lip and @rainum - if one of you takes the ui-tree task (SL-275), these helpers might help to work with those paths.