### PR TITLE
fix: handling dots-in-path case

### DIFF
--- a/src/__tests__/toPropertyPath.spec.ts
+++ b/src/__tests__/toPropertyPath.spec.ts
@@ -9,5 +9,5 @@ test('toPropertyPath', () => {
   expect(toPropertyPath('#/definitions/Error')).toEqual('definitions.Error');
   expect(toPropertyPath('/a/..dotted/path')).toEqual('a.["..dotted"].path');
   expect(toPropertyPath('/a/..dotted/path')).toEqual('a.["..dotted"].path');
-  expect(toPropertyPath('/a/..dotted.and."quoted"/path')).toEqual('a.["..dotted.and.\\\"quoted\\\""].path');
+  expect(toPropertyPath('/a/..dotted.and."quoted"/path')).toEqual('a.["..dotted.and.\\"quoted\\""].path');
 });

--- a/src/__tests__/toPropertyPath.spec.ts
+++ b/src/__tests__/toPropertyPath.spec.ts
@@ -8,4 +8,6 @@ test('toPropertyPath', () => {
   expect(toPropertyPath('/paths/foo~0users')).toEqual('paths.foo~users');
   expect(toPropertyPath('#/definitions/Error')).toEqual('definitions.Error');
   expect(toPropertyPath('/a/..dotted/path')).toEqual('a.["..dotted"].path');
+  expect(toPropertyPath('/a/..dotted/path')).toEqual('a.["..dotted"].path');
+  expect(toPropertyPath('/a/..dotted.and."quoted"/path')).toEqual('a.["..dotted.and.\\\"quoted\\\""].path');
 });

--- a/src/__tests__/toPropertyPath.spec.ts
+++ b/src/__tests__/toPropertyPath.spec.ts
@@ -7,4 +7,5 @@ test('toPropertyPath', () => {
   expect(toPropertyPath('/paths/~1~1~1~1pets/post')).toEqual('paths.////pets.post');
   expect(toPropertyPath('/paths/foo~0users')).toEqual('paths.foo~users');
   expect(toPropertyPath('#/definitions/Error')).toEqual('definitions.Error');
+  expect(toPropertyPath('/a/..dotted/path')).toEqual('a.["..dotted"].path');
 });

--- a/src/toPropertyPath.ts
+++ b/src/toPropertyPath.ts
@@ -5,6 +5,8 @@ export function toPropertyPath(path: string) {
     .replace(/^(\/|#\/)/, '')
     .split('/')
     .map(decodePointerFragment)
-    .map(fragment => (fragment.indexOf('.') > -1 ? `["${fragment}"]` : fragment))
+    .map(fragment => (fragment.indexOf('.') > -1
+      ? `["${fragment.replace(/"/g, '\\"')}"]`
+      : fragment))
     .join('.');
 }

--- a/src/toPropertyPath.ts
+++ b/src/toPropertyPath.ts
@@ -5,5 +5,6 @@ export function toPropertyPath(path: string) {
     .replace(/^(\/|#\/)/, '')
     .split('/')
     .map(decodePointerFragment)
+    .map(fragment => (fragment.indexOf('.') > -1 ? `["${fragment}"]` : fragment))
     .join('.');
 }

--- a/src/toPropertyPath.ts
+++ b/src/toPropertyPath.ts
@@ -5,8 +5,6 @@ export function toPropertyPath(path: string) {
     .replace(/^(\/|#\/)/, '')
     .split('/')
     .map(decodePointerFragment)
-    .map(fragment => (fragment.indexOf('.') > -1
-      ? `["${fragment.replace(/"/g, '\\"')}"]`
-      : fragment))
+    .map(fragment => (fragment.indexOf('.') > -1 ? `["${fragment.replace(/"/g, '\\"')}"]` : fragment))
     .join('.');
 }

--- a/src/toPropertyPath.ts
+++ b/src/toPropertyPath.ts
@@ -5,6 +5,14 @@ export function toPropertyPath(path: string) {
     .replace(/^(\/|#\/)/, '')
     .split('/')
     .map(decodePointerFragment)
-    .map(fragment => (fragment.indexOf('.') > -1 ? `["${fragment.replace(/"/g, '\\"')}"]` : fragment))
+    .map(sanitize)
     .join('.');
+}
+
+function sanitize(fragment: string) {
+  if (fragment.includes('.')) {
+    return `["${fragment.replace(/"/g, '\\"')}"]`;
+  } else {
+    return fragment;
+  }
 }


### PR DESCRIPTION
This PR fixes `toPropertyPath` function for case when there are dots in path:
`/path/to/some/.dots/`

Before: `path.to.some..dots` <- bad :(
After: `path.to.some.[".dots"]` <- good :)