### PR TITLE
fix: safeStringify should follow JSON.stringify

### DIFF
--- a/src/__tests__/safeStringify.ts
+++ b/src/__tests__/safeStringify.ts
@@ -44,6 +44,12 @@ describe('safeStringify', () => {
   it('should work', () => {
     const val = { foo: true };
     expect(safeStringify(val)).toEqual('{"foo":true}');
-    expect(safeStringify('{"foo":true}')).toEqual('{"foo":true}');
+    expect(safeStringify('{"foo":true}')).toEqual(JSON.stringify('{"foo":true}'));
+  });
+
+  it('should handle falsy values correctly', () => {
+    expect(safeStringify(null)).toBe('null');
+    expect(safeStringify(0)).toBe('0');
+    expect(safeStringify(false)).toBe('false');
   });
 });

--- a/src/__tests__/safeStringify.ts
+++ b/src/__tests__/safeStringify.ts
@@ -44,7 +44,7 @@ describe('safeStringify', () => {
   it('should work', () => {
     const val = { foo: true };
     expect(safeStringify(val)).toEqual('{"foo":true}');
-    expect(safeStringify('{"foo":true}')).toEqual(JSON.stringify('{"foo":true}'));
+    expect(safeStringify([0, 1])).toEqual('[0,1]');
   });
 
   it('should handle falsy values correctly', () => {
@@ -53,5 +53,10 @@ describe('safeStringify', () => {
     expect(safeStringify(false)).toBe('false');
     expect(safeStringify(undefined)).toBeUndefined();
     expect(safeStringify({ value: undefined })).toBe('{}');
+  });
+
+  it('should not stringify twice', () => {
+    expect(safeStringify('"0"')).toBe('"0"');
+    expect(safeStringify(JSON.stringify({ foo: 'bar' }))).toBe(JSON.stringify({ foo: 'bar' }));
   });
 });

--- a/src/__tests__/safeStringify.ts
+++ b/src/__tests__/safeStringify.ts
@@ -51,5 +51,7 @@ describe('safeStringify', () => {
     expect(safeStringify(null)).toBe('null');
     expect(safeStringify(0)).toBe('0');
     expect(safeStringify(false)).toBe('false');
+    expect(safeStringify(undefined)).toBeUndefined();
+    expect(safeStringify({ value: undefined })).toBe('{}');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './decodePointer';
 export * from './decodePointerFragment';
 export * from './encodePointer';
 export * from './encodePointerFragment';
+export * from './isStringified';
 export * from './pathToPointer';
 export * from './pointerToPath';
 export * from './safeParse';

--- a/src/isStringified.ts
+++ b/src/isStringified.ts
@@ -1,0 +1,12 @@
+export const isStringified = (val: unknown) => {
+  if (typeof val !== 'string') {
+    return false;
+  }
+
+  try {
+    JSON.parse(val as string);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/src/safeStringify.ts
+++ b/src/safeStringify.ts
@@ -1,10 +1,15 @@
 import fastStringify from '@stoplight/fast-safe-stringify';
+import { isStringified } from './isStringified';
 
 export const safeStringify = (
   value: any,
-  replacer?: (key: string, value: any) => any,
+  replacer?: (key: string, value: any) => any | Array<string | number> | null,
   space?: string | number
 ): string => {
+  if (isStringified(value)) {
+    return value;
+  }
+
   try {
     // try regular stringify first as mentioned in this tip:
     // https://github.com/davidmarkclements/fast-safe-stringify#protip

--- a/src/safeStringify.ts
+++ b/src/safeStringify.ts
@@ -5,13 +5,11 @@ export const safeStringify = (
   replacer?: (key: string, value: any) => any,
   space?: string | number
 ): string => {
-  if (!value || typeof value === 'string') return value;
-
   try {
     // try regular stringify first as mentioned in this tip:
     // https://github.com/davidmarkclements/fast-safe-stringify#protip
     return JSON.stringify(value, replacer, space);
-  } catch (_) {
+  } catch {
     return fastStringify(value, replacer, space);
   }
 };


### PR DESCRIPTION
I'm not sure if that's a design or an oversight, but our implementation of `safeStringify` is not compliant with `JSON.stringify`.
Today, when working on Studio, I noticed nulls are not stringified correctly.
This lead to a subtle errors where for instance `[null, 'foo].join('')` results in `'foo'` rather than `'nullfoo'`.
Since all falsy values are not stringified, `zero`, `false` etc. are not stringified at all as well, which, I don't think is intended.
The other issue I noticed is that we don't stringify strings - this, IMHO, is another issue.
I'd expect every string to be stringified again so that I can parse it with `JSON.parse` later on.

The former behavior is definitely an issue. I suppose we wanted to filter out `undefined` values, but by an accident, we also ignore other falsy values.
I am open to discuss the latter issue, but I stand for being on par with `JSON.stringify`.

What I'm afraid of is that `safeStringify` is used in plenty of projects and changing its behavior may cause bugs here and there.


