### PR TITLE
feat: make getLocationForJsonPath more consistent with the YAML equivalent [SO-215]

### DIFF
--- a/src/__tests__/fixtures/todos.oas2.json
+++ b/src/__tests__/fixtures/todos.oas2.json
@@ -1,0 +1,360 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "To-Dos Demo",
+    "version": "1.0",
+    "description": "This OAS2 (Swagger 2) file represents a real API that lives at http://todos.stoplight.io.\n\nFor authentication information, click the apikey security scheme in the editor sidebar.",
+    "contact": {
+      "name": "Stoplight",
+      "url": "https://stoplight.io"
+    },
+    "license": {
+      "name": "MIT"
+    }
+  },
+  "host": "todos.stoplight.io",
+  "schemes": [
+    "http"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "apikey": {
+      "name": "apikey",
+      "type": "apiKey",
+      "in": "query",
+      "description": "#### Use ?apikey=123 to authenticate requests. Super secure, we know ;)."
+    }
+  },
+  "paths": {
+    "/todos/{todoId}": {
+      "parameters": [
+        {
+          "name": "todoId",
+          "in": "path",
+          "required": true,
+          "type": "string"
+        }
+      ],
+      "get": {
+        "operationId": "GET_todo",
+        "summary": "Get Todo",
+        "tags": [
+          "Todos"
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/todo-full"
+            },
+            "examples": {
+              "application/json": {
+                "id": 1,
+                "name": "get food",
+                "completed": false,
+                "completed_at": "1955-04-23T13:22:52.685Z",
+                "created_at": "1994-11-05T03:26:51.471Z",
+                "updated_at": "1989-07-29T11:30:06.701Z"
+              },
+              "random": "{\n\t\"foo\": \"bar\"\n}\n"
+            }
+          },
+          "404": {
+            "$ref": "./shared.oas2.yml#/responses/404"
+          },
+          "500": {
+            "$ref": "./shared.oas2.yml#/responses/500"
+          }
+        }
+      },
+      "put": {
+        "operationId": "PUT_todos",
+        "summary": "Update Todo",
+        "tags": [
+          "Todos"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/todo-partial",
+              "example": {
+                "name": "my todo's new name",
+                "completed": false
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/todo-full"
+            },
+            "examples": {
+              "application/json": {
+                "id": 9000,
+                "name": "It's Over 9000!!!",
+                "completed": true,
+                "completed_at": null,
+                "created_at": "2014-08-28T14:14:28.494Z",
+                "updated_at": "2015-08-28T14:14:28.494Z"
+              }
+            }
+          },
+          "401": {
+            "$ref": "./shared.oas2.yml#/responses/401"
+          },
+          "404": {
+            "$ref": "./shared.oas2.yml#/responses/404"
+          },
+          "500": {
+            "$ref": "./shared.oas2.yml#/responses/500"
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ]
+      },
+      "delete": {
+        "operationId": "DELETE_todo",
+        "summary": "Delete Todo",
+        "tags": [
+          "Todos"
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "401": {
+            "$ref": "./shared.oas2.yml#/responses/401"
+          },
+          "404": {
+            "$ref": "./shared.oas2.yml#/responses/404"
+          },
+          "500": {
+            "$ref": "./shared.oas2.yml#/responses/500"
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ]
+      }
+    },
+    "/todos": {
+      "post": {
+        "operationId": "POST_todos",
+        "summary": "Create Todo",
+        "tags": [
+          "Todos"
+        ],
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/todo-partial",
+              "example": {
+                "name": "my todo's name",
+                "completed": false
+              }
+            }
+          },
+          {
+            "in": "header",
+            "type": "string",
+            "name": "foo"
+          },
+          {
+            "in": "query",
+            "type": "string",
+            "name": "Bar"
+          },
+          {
+            "in": "header",
+            "type": "string",
+            "name": "fee",
+            "description": "This is the description\n\nFoo bar oinwe foin \n\noiwenf oiwf "
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "",
+            "schema": {
+              "$ref": "#/definitions/todo-full"
+            },
+            "examples": {
+              "application/json": {
+                "id": 9000,
+                "name": "It's Over 9000!!!",
+                "completed": null,
+                "completed_at": null,
+                "created_at": "2014-08-28T14:14:28.494Z",
+                "updated_at": "2014-08-28T14:14:28.494Z"
+              }
+            }
+          },
+          "401": {
+            "$ref": "./shared.oas2.yml#/responses/401"
+          },
+          "500": {
+            "$ref": "./shared.oas2.yml#/responses/500"
+          }
+        },
+        "security": [
+          {
+            "apikey": []
+          }
+        ],
+        "description": "This creates a Todo object.\n\nTesting `inline code`."
+      },
+      "get": {
+        "operationId": "GET_todos",
+        "summary": "List Todos",
+        "tags": [
+          "Todos"
+        ],
+        "parameters": [
+          {
+            "$ref": "./shared.oas2.yml#/parameters/limit"
+          },
+          {
+            "$ref": "./shared.oas2.yml#/parameters/skip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/todo-full"
+              }
+            },
+            "examples": {
+              "application/json": [
+                {
+                  "id": 1,
+                  "name": "design the thingz",
+                  "completed": true
+                },
+                {
+                  "id": 2,
+                  "name": "mock the thingz",
+                  "completed": true
+                },
+                {
+                  "id": 3,
+                  "name": "code the thingz",
+                  "completed": false
+                }
+              ],
+              "empty": []
+            }
+          },
+          "500": {
+            "$ref": "./shared.oas2.yml#/responses/500"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "limit": {
+      "name": "limit",
+      "in": "query",
+      "description": "This is how it works.",
+      "required": false,
+      "type": "integer",
+      "maximum": 100
+    },
+    "skip": {
+      "name": "skip",
+      "in": "query",
+      "required": false,
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "todo-partial": {
+      "title": "Todo Partial",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "completed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "name",
+        "completed"
+      ],
+      "x-tags": [
+        "Todos"
+      ]
+    },
+    "todo-full": {
+      "title": "Todo Full",
+      "allOf": [
+        {
+          "$ref": "#/definitions/todo-partial"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 1000000
+            },
+            "completed_at": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "format": "date-time"
+            },
+            "created_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "updated_at": {
+              "type": "string",
+              "format": "date-time"
+            },
+            "user": {
+              "$ref": "../models/user.json"
+            }
+          },
+          "required": [
+            "id",
+            "user"
+          ]
+        }
+      ],
+      "x-tags": [
+        "Todos"
+      ]
+    }
+  },
+  "tags": [
+    {
+      "name": "Todos"
+    }
+  ]
+}

--- a/src/__tests__/getLocationForJsonPath.spec.ts
+++ b/src/__tests__/getLocationForJsonPath.spec.ts
@@ -7,6 +7,7 @@ const simple = fs.readFileSync(join(__dirname, './fixtures/simple.json'), 'utf-8
 const users = fs.readFileSync(join(__dirname, './fixtures/users.json'), 'utf-8');
 const multilineComments = fs.readFileSync(join(__dirname, './fixtures/multiline-comments.json'), 'utf-8');
 const petStore = fs.readFileSync(join(__dirname, './fixtures/petstore.oas2.json'), 'utf-8');
+const todos = fs.readFileSync(join(__dirname, './fixtures/todos.oas2.json'), 'utf-8');
 
 describe('getLocationForJsonPath', () => {
   describe('pet store fixture', () => {
@@ -15,6 +16,12 @@ describe('getLocationForJsonPath', () => {
     test.each`
       start       | end        | path
       ${[8, 21]}  | ${[8, 41]} | ${['info', 'contact', 'email']}
+      ${[18, 8]}  | ${[25, 9]} | ${['tags', 0]}
+      ${[18, 8]}  | ${[25, 9]} | ${['tags', 0, 0]}
+      ${[18, 8]}  | ${[25, 9]} | ${['tags', 0, 'test', 'foo']}
+      ${[26, 8]}  | ${[29, 9]} | ${['tags', 1]}
+      ${[26, 8]}  | ${[29, 9]} | ${['tags', 1, -1]}
+      ${[17, 12]} | ${[38, 5]} | ${['tags', 3, 'test', 'foo']}
       ${[39, 15]} | ${[42, 5]} | ${['schemes']}
     `('should return proper location for given JSONPath $path', ({ start, end, path }) => {
       expect(getLocationForJsonPath(result, path)).toEqual({
@@ -112,6 +119,30 @@ describe('getLocationForJsonPath', () => {
       ${[7, 14]}  | ${[7, 17]}  | ${['address', 'street']}
       ${[13, 13]} | ${[15, 7]}  | ${['paths', '/users/{id}', 'get']}
       ${[14, 23]} | ${[14, 33]} | ${['paths', '/users/{id}', 'get', 'operationId']}
+    `('should return proper location for given JSONPath $path', ({ start, end, path }) => {
+      expect(getLocationForJsonPath(result, path)).toEqual({
+        range: {
+          start: {
+            character: start[1],
+            line: start[0],
+          },
+          end: {
+            character: end[1],
+            line: end[0],
+          },
+        },
+      });
+    });
+  });
+
+  describe('todos', () => {
+    const result = parseWithPointers(todos);
+
+    test.each`
+      start       | end         | path
+      ${[42, 13]} | ${[73, 7]}  | ${['paths', '/todos/{todoId}', 'get']}
+      ${[42, 13]} | ${[73, 7]}  | ${['paths', '/todos/{todoId}', 'get', 'description']}
+      ${[74, 13]} | ${[125, 7]} | ${['paths', '/todos/{todoId}', 'put', 'description']}
     `('should return proper location for given JSONPath $path', ({ start, end, path }) => {
       expect(getLocationForJsonPath(result, path)).toEqual({
         range: {

--- a/src/__tests__/getLocationForJsonPath.spec.ts
+++ b/src/__tests__/getLocationForJsonPath.spec.ts
@@ -14,29 +14,39 @@ describe('getLocationForJsonPath', () => {
     const result = parseWithPointers(petStore);
 
     test.each`
-      start       | end        | path
-      ${[8, 21]}  | ${[8, 41]} | ${['info', 'contact', 'email']}
-      ${[8, 21]}  | ${[8, 41]} | ${['info', 'contact', 'email', 'foo']}
-      ${[18, 8]}  | ${[25, 9]} | ${['tags', 0]}
-      ${[18, 8]}  | ${[25, 9]} | ${['tags', 0, 0]}
-      ${[18, 8]}  | ${[25, 9]} | ${['tags', 0, 'test', 'foo']}
-      ${[26, 8]}  | ${[29, 9]} | ${['tags', 1]}
-      ${[26, 8]}  | ${[29, 9]} | ${['tags', 1, -1]}
-      ${[17, 12]} | ${[38, 5]} | ${['tags', 3, 'test', 'foo']}
-      ${[39, 15]} | ${[42, 5]} | ${['schemes']}
-    `('should return proper location for given JSONPath $path', ({ start, end, path }) => {
-      expect(getLocationForJsonPath(result, path)).toEqual({
-        range: {
-          start: {
-            character: start[1],
-            line: start[0],
-          },
-          end: {
-            character: end[1],
-            line: end[0],
-          },
-        },
-      });
+      start       | end        | path                                   | closest
+      ${[8, 21]}  | ${[8, 41]} | ${['info', 'contact', 'email']}        | ${false}
+      ${[8, 21]}  | ${[8, 41]} | ${['info', 'contact', 'email']}        | ${true}
+      ${[]}       | ${[]}      | ${['info', 'contact', 'email', 'foo']} | ${false}
+      ${[8, 21]}  | ${[8, 41]} | ${['info', 'contact', 'email', 'foo']} | ${true}
+      ${[18, 8]}  | ${[25, 9]} | ${['tags', 0]}                         | ${false}
+      ${[]}       | ${[]}      | ${['tags', 0, 0]}                      | ${false}
+      ${[18, 8]}  | ${[25, 9]} | ${['tags', 0, 0]}                      | ${true}
+      ${[]}       | ${[]}      | ${['tags', 0, 'test', 'foo']}          | ${false}
+      ${[18, 8]}  | ${[25, 9]} | ${['tags', 0, 'test', 'foo']}          | ${true}
+      ${[26, 8]}  | ${[29, 9]} | ${['tags', 1]}                         | ${false}
+      ${[]}       | ${[]}      | ${['tags', 1, -1]}                     | ${false}
+      ${[26, 8]}  | ${[29, 9]} | ${['tags', 1, -1]}                     | ${true}
+      ${[17, 12]} | ${[38, 5]} | ${['tags', 3, 'test', 'foo']}          | ${true}
+      ${[39, 15]} | ${[42, 5]} | ${['schemes']}                         | ${false}
+      ${[39, 15]} | ${[42, 5]} | ${['schemes']}                         | ${true}
+    `('should return proper location for given JSONPath $path', ({ start, end, path, closest }) => {
+      expect(getLocationForJsonPath(result, path, closest)).toEqual(
+        start.length > 0 && end.length > 0
+          ? {
+              range: {
+                start: {
+                  character: start[1],
+                  line: start[0],
+                },
+                end: {
+                  character: end[1],
+                  line: end[0],
+                },
+              },
+            }
+          : undefined
+      );
     });
   });
 
@@ -140,23 +150,29 @@ describe('getLocationForJsonPath', () => {
     const result = parseWithPointers(todos);
 
     test.each`
-      start       | end         | path
-      ${[42, 13]} | ${[73, 7]}  | ${['paths', '/todos/{todoId}', 'get']}
-      ${[42, 13]} | ${[73, 7]}  | ${['paths', '/todos/{todoId}', 'get', 'description']}
-      ${[74, 13]} | ${[125, 7]} | ${['paths', '/todos/{todoId}', 'put', 'description']}
-    `('should return proper location for given JSONPath $path', ({ start, end, path }) => {
-      expect(getLocationForJsonPath(result, path)).toEqual({
-        range: {
-          start: {
-            character: start[1],
-            line: start[0],
-          },
-          end: {
-            character: end[1],
-            line: end[0],
-          },
-        },
-      });
+      start       | end         | path                                                  | closest
+      ${[42, 13]} | ${[73, 7]}  | ${['paths', '/todos/{todoId}', 'get']}                | ${false}
+      ${[42, 13]} | ${[73, 7]}  | ${['paths', '/todos/{todoId}', 'get', 'description']} | ${true}
+      ${[]}       | ${[]}       | ${['paths', '/todos/{todoId}', 'get', 'description']} | ${false}
+      ${[74, 13]} | ${[125, 7]} | ${['paths', '/todos/{todoId}', 'put', 'description']} | ${true}
+      ${[]}       | ${[]}       | ${['paths', '/todos/{todoId}', 'put', 'description']} | ${false}
+    `('should return proper location for given JSONPath $path', ({ start, end, path, closest }) => {
+      expect(getLocationForJsonPath(result, path, closest)).toEqual(
+        start.length > 0 && end.length > 0
+          ? {
+              range: {
+                start: {
+                  character: start[1],
+                  line: start[0],
+                },
+                end: {
+                  character: end[1],
+                  line: end[0],
+                },
+              },
+            }
+          : undefined
+      );
     });
   });
 });

--- a/src/__tests__/getLocationForJsonPath.spec.ts
+++ b/src/__tests__/getLocationForJsonPath.spec.ts
@@ -16,6 +16,7 @@ describe('getLocationForJsonPath', () => {
     test.each`
       start       | end        | path
       ${[8, 21]}  | ${[8, 41]} | ${['info', 'contact', 'email']}
+      ${[8, 21]}  | ${[8, 41]} | ${['info', 'contact', 'email', 'foo']}
       ${[18, 8]}  | ${[25, 9]} | ${['tags', 0]}
       ${[18, 8]}  | ${[25, 9]} | ${['tags', 0, 0]}
       ${[18, 8]}  | ${[25, 9]} | ${['tags', 0, 'test', 'foo']}

--- a/src/__tests__/getLocationForJsonPath.spec.ts
+++ b/src/__tests__/getLocationForJsonPath.spec.ts
@@ -45,7 +45,7 @@ describe('getLocationForJsonPath', () => {
                 },
               },
             }
-          : undefined
+          : void 0
       );
     });
   });

--- a/src/getJsonPathForPosition.ts
+++ b/src/getJsonPathForPosition.ts
@@ -2,20 +2,17 @@ import { GetJsonPathForPosition } from '@stoplight/types';
 import { findNodeAtOffset, getNodePath } from 'jsonc-parser';
 import { IJsonASTNode } from './types';
 
-export const getJsonPathForPosition: GetJsonPathForPosition<IJsonASTNode, number[]> = (
-  { lineMap, ast },
-  position
-) => {
+export const getJsonPathForPosition: GetJsonPathForPosition<IJsonASTNode, number[]> = ({ lineMap, ast }, position) => {
   const startOffset = lineMap[position.line];
   const endOffset = lineMap[position.line + 1];
 
-  if (startOffset === undefined) {
+  if (startOffset === void 0) {
     return;
   }
 
   const node = findNodeAtOffset(
     ast,
-    endOffset === undefined ? startOffset + position.character : Math.min(endOffset, startOffset + position.character),
+    endOffset === void 0 ? startOffset + position.character : Math.min(endOffset, startOffset + position.character),
     true
   );
 

--- a/src/getLocationForJsonPath.ts
+++ b/src/getLocationForJsonPath.ts
@@ -1,8 +1,12 @@
 import { GetLocationForJsonPath, JsonPath } from '@stoplight/types';
 import { IJsonASTNode } from './types';
 
-export const getLocationForJsonPath: GetLocationForJsonPath<IJsonASTNode, number[]> = ({ lineMap, ast }, path) => {
-  const node = findNodeAtPath(ast, path) as IJsonASTNode;
+export const getLocationForJsonPath: GetLocationForJsonPath<IJsonASTNode, number[]> = (
+  { lineMap, ast },
+  path,
+  closest = false
+) => {
+  const node = findNodeAtPath(ast, path, closest) as IJsonASTNode;
 
   if (node === undefined || node.range === undefined) {
     return;
@@ -12,11 +16,11 @@ export const getLocationForJsonPath: GetLocationForJsonPath<IJsonASTNode, number
 };
 
 // based on source code of https://github.com/microsoft/node-jsonc-parser
-function findNodeAtPath(node: IJsonASTNode, path: JsonPath): IJsonASTNode | undefined {
+function findNodeAtPath(node: IJsonASTNode, path: JsonPath, closest: boolean): IJsonASTNode | undefined {
   pathLoop: for (const segment of path) {
     if (typeof segment === 'string') {
       if (node.type !== 'object' || !Array.isArray(node.children)) {
-        return node;
+        return closest ? node : undefined;
       }
 
       for (const propertyNode of node.children) {
@@ -25,9 +29,11 @@ function findNodeAtPath(node: IJsonASTNode, path: JsonPath): IJsonASTNode | unde
           continue pathLoop;
         }
       }
+
+      return closest ? node : undefined;
     } else {
       if (node.type !== 'array' || segment < 0 || !Array.isArray(node.children) || segment >= node.children.length) {
-        return node;
+        return closest ? node : undefined;
       }
 
       node = node.children[segment];

--- a/src/getLocationForJsonPath.ts
+++ b/src/getLocationForJsonPath.ts
@@ -8,7 +8,7 @@ export const getLocationForJsonPath: GetLocationForJsonPath<IJsonASTNode, number
 ) => {
   const node = findNodeAtPath(ast, path, closest) as IJsonASTNode;
 
-  if (node === undefined || node.range === undefined) {
+  if (node === void 0 || node.range === void 0) {
     return;
   }
 
@@ -20,7 +20,7 @@ function findNodeAtPath(node: IJsonASTNode, path: JsonPath, closest: boolean): I
   pathLoop: for (const segment of path) {
     if (typeof segment === 'string') {
       if (node.type !== 'object' || !Array.isArray(node.children)) {
-        return closest ? node : undefined;
+        return closest ? node : void 0;
       }
 
       for (const propertyNode of node.children) {
@@ -30,10 +30,10 @@ function findNodeAtPath(node: IJsonASTNode, path: JsonPath, closest: boolean): I
         }
       }
 
-      return closest ? node : undefined;
+      return closest ? node : void 0;
     } else {
       if (node.type !== 'array' || segment < 0 || !Array.isArray(node.children) || segment >= node.children.length) {
-        return closest ? node : undefined;
+        return closest ? node : void 0;
       }
 
       node = node.children[segment];

--- a/src/getLocationForJsonPath.ts
+++ b/src/getLocationForJsonPath.ts
@@ -1,9 +1,8 @@
-import { GetLocationForJsonPath } from '@stoplight/types';
-import { findNodeAtLocation } from 'jsonc-parser';
+import { GetLocationForJsonPath, JsonPath } from '@stoplight/types';
 import { IJsonASTNode } from './types';
 
 export const getLocationForJsonPath: GetLocationForJsonPath<IJsonASTNode, number[]> = ({ lineMap, ast }, path) => {
-  const node = findNodeAtLocation(ast, path) as IJsonASTNode;
+  const node = findNodeAtPath(ast, path) as IJsonASTNode;
 
   if (node === undefined || node.range === undefined) {
     return;
@@ -11,3 +10,29 @@ export const getLocationForJsonPath: GetLocationForJsonPath<IJsonASTNode, number
 
   return { range: node.range };
 };
+
+// based on source code of https://github.com/microsoft/node-jsonc-parser
+function findNodeAtPath(node: IJsonASTNode, path: JsonPath): IJsonASTNode | undefined {
+  pathLoop: for (const segment of path) {
+    if (typeof segment === 'string') {
+      if (node.type !== 'object' || !Array.isArray(node.children)) {
+        return node;
+      }
+
+      for (const propertyNode of node.children) {
+        if (Array.isArray(propertyNode.children) && propertyNode.children[0].value === segment) {
+          node = propertyNode.children[1];
+          continue pathLoop;
+        }
+      }
+    } else {
+      if (node.type !== 'array' || segment < 0 || !Array.isArray(node.children) || segment >= node.children.length) {
+        return node;
+      }
+
+      node = node.children[segment];
+    }
+  }
+
+  return node;
+}

--- a/src/safeParse.ts
+++ b/src/safeParse.ts
@@ -12,7 +12,7 @@ export const safeParse: JSON['parse'] = <T>(text: string, reviver?: (key: any, v
 
     return JSON.parse(text, reviver);
   } catch (e) {
-    return undefined;
+    return void 0;
   }
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,9 +706,9 @@
     typedoc "0.14.2"
 
 "@stoplight/types@5.x.x":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-5.0.0.tgz#5d17224f4ba727a1ec7b4e1397f330fab2e2f0de"
-  integrity sha512-ttAHp4lBiO+0uILKj0poYNFnjPR49CZObPhbba+M7Ss1UUSgo8PlQXaVKxh4klxU8ldgIqTpM+w9bW7Fth/JrQ==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-5.1.0.tgz#33fb18d8927e2538b2f0b19edc076d6f7e3a9978"
+  integrity sha512-GKOcgmwDMJyg09WmI4irIiq7d32hwlqyrdAqpV4b/Eg6/XT2e3g8spguiOsQKIqQSvZqSrrfpGWn/ENCPBvFEA==
 
 "@types/babel__core@^7.1.0":
   version "7.1.1"
@@ -2072,7 +2072,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -3257,7 +3257,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -4381,7 +4381,7 @@ libnpm@^2.0.1:
     read-package-json "^2.0.13"
     stringify-package "^1.0.0"
 
-libnpmaccess@*, libnpmaccess@^3.0.1:
+libnpmaccess@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-3.0.1.tgz#5b3a9de621f293d425191aa2e779102f84167fa8"
   integrity sha512-RlZ7PNarCBt+XbnP7R6PoVgOq9t+kou5rvhaInoNibhPO7eMlRfS0B8yjatgn2yaHIwWNyoJDolC/6Lc5L/IQA==
@@ -4418,7 +4418,7 @@ libnpmhook@^5.0.2:
     get-stream "^4.0.0"
     npm-registry-fetch "^3.8.0"
 
-libnpmorg@*, libnpmorg@^1.0.0:
+libnpmorg@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/libnpmorg/-/libnpmorg-1.0.0.tgz#979b868c48ba28c5820e3bb9d9e73c883c16a232"
   integrity sha512-o+4eVJBoDGMgRwh2lJY0a8pRV2c/tQM/SxlqXezjcAg26Qe9jigYVs+Xk0vvlYDWCDhP0g74J8UwWeAgsB7gGw==
@@ -4443,7 +4443,7 @@ libnpmpublish@^1.1.0:
     semver "^5.5.1"
     ssri "^6.0.1"
 
-libnpmsearch@*, libnpmsearch@^2.0.0:
+libnpmsearch@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/libnpmsearch/-/libnpmsearch-2.0.0.tgz#de05af47ada81554a5f64276a69599070d4a5685"
   integrity sha512-vd+JWbTGzOSfiOc+72MU6y7WqmBXn49egCCrIXp27iE/88bX8EpG64ST1blWQI1bSMUr9l1AKPMVsqa2tS5KWA==
@@ -4452,7 +4452,7 @@ libnpmsearch@*, libnpmsearch@^2.0.0:
     get-stream "^4.0.0"
     npm-registry-fetch "^3.8.0"
 
-libnpmteam@*, libnpmteam@^1.0.1:
+libnpmteam@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/libnpmteam/-/libnpmteam-1.0.1.tgz#ff704b1b6c06ea674b3b1101ac3e305f5114f213"
   integrity sha512-gDdrflKFCX7TNwOMX1snWojCoDE5LoRWcfOC0C/fqF7mBq8Uz9zWAX4B2RllYETNO7pBupBaSyBDkTAC15cAMg==
@@ -4597,11 +4597,6 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4610,32 +4605,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@~3.0.0:
   version "3.0.0"
@@ -4681,11 +4654,6 @@ lodash.map@^4.5.1:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -5446,15 +5414,6 @@ npm-pick-manifest@^2.1.0, npm-pick-manifest@^2.2.3:
     npm-package-arg "^6.0.0"
     semver "^5.4.1"
 
-npm-profile@*, npm-profile@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/npm-profile/-/npm-profile-4.0.1.tgz#d350f7a5e6b60691c7168fbb8392c3603583f5aa"
-  integrity sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==
-  dependencies:
-    aproba "^1.1.2 || 2"
-    figgy-pudding "^3.4.1"
-    npm-registry-fetch "^3.8.0"
-
 npm-profile@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/npm-profile/-/npm-profile-3.0.2.tgz#58d568f1b56ef769602fd0aed8c43fa0e0de0f57"
@@ -5462,6 +5421,15 @@ npm-profile@^3.0.2:
   dependencies:
     aproba "^1.1.2 || 2"
     make-fetch-happen "^2.5.0 || 3 || 4"
+
+npm-profile@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-profile/-/npm-profile-4.0.1.tgz#d350f7a5e6b60691c7168fbb8392c3603583f5aa"
+  integrity sha512-NQ1I/1Q7YRtHZXkcuU1/IyHeLy6pd+ScKg4+DQHdfsm769TGq6HPrkbuNJVJS4zwE+0mvvmeULzQdWn2L2EsVA==
+  dependencies:
+    aproba "^1.1.2 || 2"
+    figgy-pudding "^3.4.1"
+    npm-registry-fetch "^3.8.0"
 
 npm-registry-client@^8.6.0:
   version "8.6.0"
@@ -6544,7 +6512,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
   integrity sha1-n6+jfShr5dksuuve4DDcm19AZ0c=


### PR DESCRIPTION
There was a minor inconsistency between JSON variant of `getLocationForJsonPath` and the YAML one.
In the case of YAML, the lookup is more relaxed and does not bail out entirely if a node at a given path does not exist.
It always returns the closest node while the JSON equivalent returns undefined.
This lead to a few subtle issues with Spectral relaxed returns the closest parent for a given path.
This PR unifies it and makes results more predictable.