### PR TITLE
fix: return undefined when no node is found at given position

### DIFF
--- a/src/__tests__/getJsonPathForPosition.spec.ts
+++ b/src/__tests__/getJsonPathForPosition.spec.ts
@@ -13,7 +13,7 @@ describe('getJsonPathForPosition', () => {
 
     test.each`
       line | character | path
-      ${0} | ${0}      | ${[]}
+      ${0} | ${0}      | ${void 0}
       ${1} | ${4}      | ${['hello']}
       ${1} | ${17}     | ${['hello']}
       ${3} | ${5}      | ${['address', 'street']}
@@ -28,8 +28,8 @@ describe('getJsonPathForPosition', () => {
 
     test.each`
       line | character | path
-      ${0} | ${0}      | ${[]}
-      ${0} | ${231}    | ${[]}
+      ${0} | ${0}      | ${void 0}
+      ${0} | ${231}    | ${void 0}
       ${2} | ${0}      | ${['users']}
       ${2} | ${3}      | ${['users']}
       ${2} | ${5}      | ${['users', 0]}

--- a/src/getJsonPathForPosition.ts
+++ b/src/getJsonPathForPosition.ts
@@ -20,5 +20,8 @@ export const getJsonPathForPosition: GetJsonPathForPosition<IJsonASTNode, number
     return;
   }
 
-  return getNodePath(node);
+  const path = getNodePath(node);
+  if (path.length === 0) return;
+
+  return path;
 };


### PR DESCRIPTION
YAML's equivalent returns undefined.