### PR TITLE
perf: remove toNumber/toString/isInfinite

### DIFF
--- a/src/safeParse.ts
+++ b/src/safeParse.ts
@@ -1,5 +1,3 @@
-import { isFinite, toNumber, toString } from 'lodash';
-
 export const safeParse: JSON['parse'] = <T>(
   text: string,
   reviver?: (key: any, value: any) => any,
@@ -18,11 +16,11 @@ export const safeParse: JSON['parse'] = <T>(
 };
 
 const parseNumber = (string: string): number | string => {
-  const numVal = toNumber(string);
+  const numVal = Number(string);
 
   // For large number javascript maniuplates data, check if converted num is same as original
-  if (isFinite(numVal)) {
-    if (toString(numVal) === string) {
+  if (Number.isFinite(numVal)) {
+    if (String(numVal) === string) {
       return numVal;
     }
 


### PR DESCRIPTION
![Screenshot_20190822_140418](https://user-images.githubusercontent.com/9273484/63515339-ebdc8580-c4ea-11e9-9905-70d889b20b1e.png)

That replace was very expensive in case of huge strings.
Decided to remove other utils - do not really think we need to use them.