### PR TITLE
fix: include properties with empty string as key

### DIFF
--- a/src/__tests__/parseWithPointers.ts
+++ b/src/__tests__/parseWithPointers.ts
@@ -201,4 +201,10 @@ describe('json parser', () => {
       }),
     ]);
   });
+
+  test('includes properties with empty string as keys', () => {
+    expect(parseWithPointers('{ "": [{ "foo": true, "": false }] }')).toHaveProperty('data', {
+      '': [{ '': false, foo: true }],
+    });
+  });
 });

--- a/src/parseWithPointers.ts
+++ b/src/parseWithPointers.ts
@@ -62,7 +62,7 @@ export function parseTree<T>(
   function onParsedValue(value: any) {
     if (Array.isArray(currentParsedParent)) {
       (currentParsedParent as any[]).push(value);
-    } else if (currentParsedProperty) {
+    } else if (currentParsedProperty !== null) {
       currentParsedParent[currentParsedProperty] = value;
     }
   }


### PR DESCRIPTION
Fixes https://github.com/stoplightio/studio/issues/123 