### PR TITLE
fix: only bundle local refs

### DIFF
--- a/src/__tests__/bundle.spec.ts
+++ b/src/__tests__/bundle.spec.ts
@@ -59,4 +59,64 @@ describe('bundleTargetPath()', () => {
       },
     });
   });
+
+  it('should not throw erorr', () => {
+    const document = {
+      definitions: {
+        user: {
+          id: 'foo',
+          address: {
+            $ref: '#/definitions/address',
+          },
+        },
+        address: {
+          street: 'foo',
+          user: {
+            $ref: '#/definitions/user',
+          },
+        },
+      },
+      __target__: {
+        entity: {
+          $ref: '#/definitions/user',
+        },
+        entity2: {
+          $ref: './path/to/pet.json',
+        },
+      },
+    };
+
+    const clone = cloneDeep(document);
+
+    const result = bundleTarget({
+      document: clone,
+      path: '#/__target__',
+    });
+
+    // Do not mutate document
+    expect(clone).toEqual(document);
+
+    expect(result).toEqual({
+      entity: {
+        $ref: '#/definitions/user',
+      },
+      entity2: {
+        $ref: './path/to/pet.json',
+      },
+      definitions: {
+        user: {
+          id: 'foo',
+          address: {
+            $ref: '#/definitions/address',
+          },
+        },
+        address: {
+          street: 'foo',
+          user: {
+            $ref: '#/definitions/user',
+          },
+        },
+      },
+    });
+  });
 });

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,5 +1,6 @@
 import { cloneDeep, get, set } from 'lodash';
 
+import { isLocalRef } from './isLocalRef';
 import { pointerToPath } from './pointerToPath';
 import { traverse } from './traverse';
 
@@ -10,7 +11,7 @@ const _bundle = (document: unknown, path: string, cur?: unknown) => {
   const objectToBundle = get(document, pointerToPath(path));
 
   traverse(cur ? cur : objectToBundle, ({ property, propertyValue }) => {
-    if (property === '$ref' && typeof propertyValue === 'string') {
+    if (property === '$ref' && typeof propertyValue === 'string' && isLocalRef(propertyValue)) {
       const _path = pointerToPath(propertyValue);
       const bundled$Ref = get(document, _path);
       const exists = !!get(objectToBundle, _path);


### PR DESCRIPTION
We use the bundle target in function in our export service if a ref isn't resolved, and it's to a file, an error was being thrown.

Now we no longer throw an error.