### PR TITLE
fix: bundleTarget should maintain array or object from original source

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   },
   "dependencies": {
     "@stoplight/ordered-object-literal": "^1.0.1",
-    "@stoplight/types": "^11.4.0",
-    "jsonc-parser": "~2.2.0",
+    "@stoplight/types": "^11.6.0",
+    "jsonc-parser": "~2.2.1",
     "lodash": "^4.17.15",
     "safe-stable-stringify": "^1.1"
   },

--- a/src/__tests__/bundle.spec.ts
+++ b/src/__tests__/bundle.spec.ts
@@ -126,9 +126,9 @@ describe('bundleTargetPath()', () => {
         {},
         {
           schema: {
-            name: 'param'
-          }
-        }
+            name: 'param',
+          },
+        },
       ],
       responses: {
         '200': {
@@ -136,9 +136,9 @@ describe('bundleTargetPath()', () => {
           schema: {
             title: 'OK',
             parameter: {
-              $ref: '#/parameters/1/schema'
-            }
-          }
+              $ref: '#/parameters/1/schema',
+            },
+          },
         },
       },
       __target__: {
@@ -166,18 +166,18 @@ describe('bundleTargetPath()', () => {
         undefined,
         {
           schema: {
-            name: 'param'
-          }
-        }
+            name: 'param',
+          },
+        },
       ],
       responses: {
         '200': {
           schema: {
             title: 'OK',
             parameter: {
-              $ref: '#/parameters/1/schema'
-            }
-          }
+              $ref: '#/parameters/1/schema',
+            },
+          },
         },
       },
     });

--- a/src/__tests__/bundle.spec.ts
+++ b/src/__tests__/bundle.spec.ts
@@ -119,4 +119,67 @@ describe('bundleTargetPath()', () => {
       },
     });
   });
+
+  it('should mirror original source decision re arrays or objects', () => {
+    const document = {
+      parameters: [
+        {},
+        {
+          schema: {
+            name: 'param'
+          }
+        }
+      ],
+      responses: {
+        '200': {
+          other: 'foo',
+          schema: {
+            title: 'OK',
+            parameter: {
+              $ref: '#/parameters/1/schema'
+            }
+          }
+        },
+      },
+      __target__: {
+        entity: {
+          $ref: '#/responses/200/schema',
+        },
+      },
+    };
+
+    const clone = cloneDeep(document);
+
+    const result = bundleTarget({
+      document: clone,
+      path: '#/__target__',
+    });
+
+    // Do not mutate document
+    expect(clone).toEqual(document);
+
+    expect(result).toEqual({
+      entity: {
+        $ref: '#/responses/200/schema',
+      },
+      parameters: [
+        undefined,
+        {
+          schema: {
+            name: 'param'
+          }
+        }
+      ],
+      responses: {
+        '200': {
+          schema: {
+            title: 'OK',
+            parameter: {
+              $ref: '#/parameters/1/schema'
+            }
+          }
+        },
+      },
+    });
+  });
 });

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -1,4 +1,4 @@
-import { cloneDeep, get, set, has } from 'lodash';
+import { cloneDeep, get, has, set } from 'lodash';
 
 import { isLocalRef } from './isLocalRef';
 import { pointerToPath } from './pointerToPath';
@@ -19,13 +19,12 @@ const _bundle = (document: unknown, path: string, cur?: unknown) => {
         const pathProcessed = [];
 
         // make sure arrays and object decisions are preserved when copying over the portion of the tree
-        for (const index in _path) {
-          const key = _path[index];
+        for (const key of _path) {
           pathProcessed.push(key);
 
           if (has(objectToBundle, pathProcessed)) continue;
 
-          const target = get(document, pathProcessed)
+          const target = get(document, pathProcessed);
           if (Array.isArray(target)) {
             set(objectToBundle, pathProcessed, []);
           } else if (typeof target === 'object') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -827,12 +827,13 @@
     shelljs "0.8.x"
     tslib "1.9.3"
 
-"@stoplight/types@^11.4.0":
-  version "11.4.0"
-  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-11.4.0.tgz#a2bedbbec37700d3c5a8c7d36c763a61d7a8bce7"
-  integrity sha512-kMh1Sv7bA8BdbUaRXsRyi2K8Y5PzPOUWNSjB4qKOi0P6+dLczjlKggEIw9Xzuu1tCgBFdEvNwjnYDey0iqgeZQ==
+"@stoplight/types@^11.6.0":
+  version "11.6.0"
+  resolved "https://registry.yarnpkg.com/@stoplight/types/-/types-11.6.0.tgz#c4507f564ea4be719f66ae2fd2bb83f4719c2210"
+  integrity sha512-J2wOl6FlN4IeY99MZTbgLVbIqrE9eVcHIvWmSEFzxfnbHCh4reXcGkvxlQ7I/pTKScd5/F/HJKSYnNXRjCnM2A==
   dependencies:
-    "@types/json-schema" "^7.0.3"
+    "@types/json-schema" "^7.0.4"
+    utility-types "^3.10.0"
 
 "@types/babel__core@^7.1.0":
   version "7.1.3"
@@ -918,10 +919,10 @@
   dependencies:
     "@types/jest-diff" "*"
 
-"@types/json-schema@^7.0.3":
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
-  integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
+"@types/json-schema@^7.0.4":
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
+  integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
 "@types/lodash@^4.14.144":
   version "4.14.144"
@@ -2742,12 +2743,7 @@ fast-glob@^3.0.3:
     merge2 "^1.3.0"
     micromatch "^4.0.2"
 
-fast-json-stable-stringify@2.x:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
-  integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
-
-fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -4481,10 +4477,10 @@ json5@2.x, json5@^2.1.0:
   dependencies:
     minimist "^1.2.0"
 
-jsonc-parser@~2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.2.0.tgz#f206f87f9d49d644b7502052c04e82dd6392e9ef"
-  integrity sha512-4fLQxW1j/5fWj6p78vAlAafoCKtuBm6ghv+Ij5W2DrDx0qE+ZdEl2c6Ko1mgJNF5ftX1iEWQQ4Ap7+3GlhjkOA==
+jsonc-parser@~2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.2.1.tgz#db73cd59d78cce28723199466b2a03d1be1df2bc"
+  integrity sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==
 
 jsonfile@^4.0.0:
   version "4.0.0"
@@ -5314,12 +5310,12 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@1.2.0, minimist@^1.1.1, minimist@^1.1.3:
+minimist@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
-minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -5732,7 +5728,6 @@ npm@^6.10.3, npm@^6.8.0:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -5747,7 +5742,6 @@ npm@^6.10.3, npm@^6.8.0:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -5766,14 +5760,8 @@ npm@^6.10.3, npm@^6.8.0:
     libnpx "^10.2.2"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -6067,17 +6055,10 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.0.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
-  dependencies:
-    p-try "^2.0.0"
-
-p-limit@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
-  integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==
   dependencies:
     p-try "^2.0.0"
 
@@ -6939,14 +6920,7 @@ resolve@1.10.1:
   dependencies:
     path-parse "^1.0.6"
 
-resolve@1.x, resolve@^1.1.6, resolve@^1.3.2:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
-  integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.10.0:
+resolve@1.x, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -8222,6 +8196,11 @@ util.promisify@^1.0.0:
   dependencies:
     define-properties "^1.1.2"
     object.getownpropertydescriptors "^2.0.3"
+
+utility-types@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/utility-types/-/utility-types-3.10.0.tgz#ea4148f9a741015f05ed74fd615e1d20e6bed82b"
+  integrity sha512-O11mqxmi7wMKCo6HKFt5AhO4BwY3VV68YU07tgxfz8zJTIxr4BpsezN49Ffwy9j3ZpwwJp4fkRwjRzq3uWE6Rg==
 
 uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"


### PR DESCRIPTION
Before, when bundling $refs to things like response codes (which are numbers) e.g. `200`, it would create an array with 199 undefined elements, and then the object in the 200th spot, rather than an object with a `200` property on it.

Added a test to demonstrate the correct behavior.