### PR TITLE
fix: don't mutate the object being traversed

### DIFF
--- a/src/__tests__/bundle.spec.ts
+++ b/src/__tests__/bundle.spec.ts
@@ -1,6 +1,7 @@
 import { cloneDeep } from 'lodash';
 
 import { BUNDLE_ROOT, bundleTarget } from '../bundle';
+import { safeStringify } from '../safeStringify';
 
 describe('bundleTargetPath()', () => {
   it('should work', () => {
@@ -299,44 +300,35 @@ describe('bundleTargetPath()', () => {
     // Do not mutate document
     expect(clone).toEqual(document);
 
-    expect(result).toEqual({
-      title: 'Hello',
-      type: 'object',
-      properties: {
-        Hello: {
-          $ref: `#/${BUNDLE_ROOT}/components/schemas/Hello`,
-        },
-        World: {
-          $ref: `#/${BUNDLE_ROOT}/components/schemas/World`,
-        },
-      },
-      [BUNDLE_ROOT]: {
-        components: {
-          schemas: {
-            Hello: {
-              title: 'Hello',
-              type: 'object',
-              properties: {
-                Hello: {
-                  $ref: `#/${BUNDLE_ROOT}/components/schemas/Hello`,
+    expect(safeStringify(result)).toEqual(
+      safeStringify({
+        [BUNDLE_ROOT]: {
+          components: {
+            schemas: {
+              Hello: '[Circular]',
+              World: {
+                properties: {
+                  name: {
+                    type: 'string',
+                  },
                 },
-                World: {
-                  $ref: `#/${BUNDLE_ROOT}/components/schemas/World`,
-                },
-              },
-            },
-            World: {
-              title: 'World',
-              type: 'object',
-              properties: {
-                name: {
-                  type: 'string',
-                },
+                title: 'World',
+                type: 'object',
               },
             },
           },
         },
-      },
-    });
+        properties: {
+          Hello: {
+            $ref: `#/${BUNDLE_ROOT}/components/schemas/Hello`,
+          },
+          World: {
+            $ref: `#/${BUNDLE_ROOT}/components/schemas/World`,
+          },
+        },
+        title: 'Hello',
+        type: 'object',
+      }),
+    );
   });
 });

--- a/src/__tests__/bundle.spec.ts
+++ b/src/__tests__/bundle.spec.ts
@@ -261,32 +261,32 @@ describe('bundleTargetPath()', () => {
 
   it('should handle circular $ref', () => {
     const document = {
-      "openapi": "3.0.0",
-      "components": {
-        "schemas": {
-          "Hello": {
-            "title": "Hello",
-            "type": "object",
-            "properties": {
-              "Hello": {
-                "$ref": "#/components/schemas/Hello"
+      openapi: '3.0.0',
+      components: {
+        schemas: {
+          Hello: {
+            title: 'Hello',
+            type: 'object',
+            properties: {
+              Hello: {
+                $ref: '#/components/schemas/Hello',
               },
-              "World": {
-                "$ref": "#/components/schemas/World"
+              World: {
+                $ref: '#/components/schemas/World',
               },
-            }
+            },
           },
-          "World": {
-            "title": "World",
-            "type": "object",
-            "properties": {
-              "name": {
-                "type": "string"
-              }
-            }
-          }
-        }
-      }
+          World: {
+            title: 'World',
+            type: 'object',
+            properties: {
+              name: {
+                type: 'string',
+              },
+            },
+          },
+        },
+      },
     };
 
     const clone = cloneDeep(document);
@@ -300,42 +300,42 @@ describe('bundleTargetPath()', () => {
     expect(clone).toEqual(document);
 
     expect(result).toEqual({
-      "title": "Hello",
-      "type": "object",
-      "properties": {
-        "Hello": {
-          "$ref": `#/${BUNDLE_ROOT}/components/schemas/Hello`
+      title: 'Hello',
+      type: 'object',
+      properties: {
+        Hello: {
+          $ref: `#/${BUNDLE_ROOT}/components/schemas/Hello`,
         },
-        "World": {
-          "$ref": `#/${BUNDLE_ROOT}/components/schemas/World`
+        World: {
+          $ref: `#/${BUNDLE_ROOT}/components/schemas/World`,
         },
       },
       [BUNDLE_ROOT]: {
-        "components": {
-          "schemas": {
-            "Hello": {
-              "title": "Hello",
-              "type": "object",
-              "properties": {
-                "Hello": {
-                  "$ref": `#/${BUNDLE_ROOT}/components/schemas/Hello`
+        components: {
+          schemas: {
+            Hello: {
+              title: 'Hello',
+              type: 'object',
+              properties: {
+                Hello: {
+                  $ref: `#/${BUNDLE_ROOT}/components/schemas/Hello`,
                 },
-                "World": {
-                  "$ref": `#/${BUNDLE_ROOT}/components/schemas/World`
+                World: {
+                  $ref: `#/${BUNDLE_ROOT}/components/schemas/World`,
                 },
-              }
+              },
             },
-            "World": {
-              "title": "World",
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
+            World: {
+              title: 'World',
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string',
+                },
+              },
+            },
+          },
+        },
       },
     });
   });

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -11,7 +11,13 @@ export const BUNDLE_ROOT = '__bundled__';
 export const bundleTarget = <T = unknown>({ document, path }: { document: T; path: string }, cur?: unknown) =>
   _bundle(cloneDeep(document), path, cur);
 
-const _bundle = (document: unknown, path: string, cur?: unknown, bundledRefInventory: any = {}) => {
+const _bundle = (
+  document: unknown,
+  path: string,
+  cur?: unknown,
+  bundledRefInventory: any = {},
+  bundledObj: any = {},
+) => {
   const objectToBundle = get(document, pointerToPath(path));
 
   traverse(cur ? cur : objectToBundle, ({ parent }) => {
@@ -39,21 +45,23 @@ const _bundle = (document: unknown, path: string, cur?: unknown, bundledRefInven
           pathProcessed.push(key);
 
           const inventoryPathProcessed = [BUNDLE_ROOT, ...pathProcessed];
-          if (has(objectToBundle, inventoryPathProcessed)) continue;
+          if (has(bundledObj, inventoryPathProcessed)) continue;
 
           const target = get(document, pathProcessed);
           if (Array.isArray(target)) {
-            set(objectToBundle, inventoryPathProcessed, []);
+            set(bundledObj, inventoryPathProcessed, []);
           } else if (typeof target === 'object') {
-            set(objectToBundle, inventoryPathProcessed, {});
+            set(bundledObj, inventoryPathProcessed, {});
           }
         }
 
-        set(objectToBundle, inventoryPath, bundled$Ref);
-        _bundle(document, path, bundled$Ref, bundledRefInventory);
+        set(bundledObj, inventoryPath, bundled$Ref);
+        _bundle(document, path, bundled$Ref, bundledRefInventory, bundledObj);
       }
     }
   });
+
+  set(objectToBundle, BUNDLE_ROOT, bundledObj[BUNDLE_ROOT]);
 
   return objectToBundle;
 };


### PR DESCRIPTION
We were mutating [objectToBundle](https://github.com/stoplightio/json/blob/dabccdafa5dcb6047d3d1c5ef25703169da9af75/../../Stoplight/json/src/bundle.ts#L21) while also traversing it, which for circular $refs caused an infinite loop 😱 . Not sure if this is the proper way to handle it though.

- fixes https://github.com/stoplightio/platform-internal/issues/3311
- https://stoplight-internal.slack.com/archives/C014Q4UK3NZ/p1593795467000500