### PR TITLE
fix: collect errors while bundling

### DIFF
--- a/src/__tests__/bundle.spec.ts
+++ b/src/__tests__/bundle.spec.ts
@@ -125,6 +125,95 @@ describe('bundleTargetPath()', () => {
     });
   });
 
+  it('should ignore invalid pointers', () => {
+    const document = {
+      practice: {
+        title: 'Account',
+        allOf: [
+          {
+            $ref: '#./UuidModel',
+          },
+          {
+            type: 'object',
+            properties: {
+              address: {
+                $ref: '#./Address',
+              },
+              email: {
+                type: 'string',
+                format: 'email',
+              },
+              name: {
+                type: 'string',
+              },
+              phone: {
+                type: 'string',
+              },
+              website: {
+                type: 'string',
+                format: 'uri',
+              },
+              owner: {
+                $ref: '#./Account',
+              },
+            },
+            required: ['name'],
+          },
+        ],
+      },
+    };
+
+    const clone = cloneDeep(document);
+
+    const result = bundleTarget({
+      document: clone,
+      path: '#/practice',
+    });
+
+    // Do not mutate document
+    expect(clone).toEqual(document);
+
+    expect(result).toEqual({
+      title: 'Account',
+      allOf: [
+        {
+          $ref: '#./UuidModel',
+        },
+        {
+          type: 'object',
+          properties: {
+            address: {
+              $ref: '#./Address',
+            },
+            email: {
+              type: 'string',
+              format: 'email',
+            },
+            name: {
+              type: 'string',
+            },
+            phone: {
+              type: 'string',
+            },
+            website: {
+              type: 'string',
+              format: 'uri',
+            },
+            owner: {
+              $ref: '#./Account',
+            },
+          },
+          required: ['name'],
+        },
+      ],
+      __errors__: {
+        '#./UuidModel': 'Invalid JSON Pointer syntax.',
+        '#./Address': 'Invalid JSON Pointer syntax.',
+        '#./Account': 'Invalid JSON Pointer syntax.',
+      },
+    });
+  });
+
   it('should mirror original source decision re arrays or objects', () => {
     const document = {
       parameters: [

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -48,7 +48,6 @@ const _bundle = (
       // Ignore invalid $refs and carry on
       if (!_path || !inventoryPath || !inventoryRef) return;
 
-
       const bundled$Ref = get(document, _path);
       if (bundled$Ref) {
         const pathProcessed = [];


### PR DESCRIPTION
Right now we're throwing an error on the first invalid pointer. In order to provide a better experience to the end user, let's take a similar approach as `json-schema-ref-parser` and continue on error. Then similar to the `__bundled__` object, we can set a `__errors__` and display the invalid $refs to the user.

- Related to https://github.com/stoplightio/platform-internal/issues/3429