### PR TITLE
 fix(bundle): ensure lack of sparse arrays in output 

### DIFF
--- a/src/__tests__/bundle.spec.ts
+++ b/src/__tests__/bundle.spec.ts
@@ -1,6 +1,7 @@
-import { cloneDeep } from 'lodash';
+import { cloneDeep, get } from 'lodash';
 
 import { BUNDLE_ROOT, bundleTarget } from '../bundle';
+import { pointerToPath } from '../pointerToPath';
 import { safeStringify } from '../safeStringify';
 
 describe('bundleTargetPath()', () => {
@@ -555,5 +556,56 @@ describe('bundleTargetPath()', () => {
     expect(clone).toEqual(document);
 
     expect(result).toMatchSnapshot();
+  });
+
+  test('should not create sparse arrays', () => {
+    const document = {
+      components: {
+        schemas: {
+          foo: {
+            allOf: [
+              {},
+              {
+                type: 'object',
+                properties: {
+                  attributes: {
+                    allOf: [{}, {}],
+                  },
+                },
+              },
+            ],
+          },
+          foo_again: {
+            allOf: [
+              {
+                $ref: '#/components/schemas/foo/allOf/0',
+              },
+              {
+                type: 'object',
+                properties: {
+                  attributes: {
+                    allOf: [
+                      {},
+                      {
+                        $ref: '#/components/schemas/foo/allOf/1/properties/attributes/allOf/1',
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    const result = bundleTarget({
+      document,
+      path: '#/components/schemas/foo_again',
+    });
+
+    expect(
+      '0' in get(result, pointerToPath('#/__bundled__/components/schemas/foo/allOf/1/properties/attributes/allOf')),
+    ).toBe(true);
   });
 });

--- a/src/__tests__/bundle.spec.ts
+++ b/src/__tests__/bundle.spec.ts
@@ -558,7 +558,7 @@ describe('bundleTargetPath()', () => {
     expect(result).toMatchSnapshot();
   });
 
-  test('should not create sparse arrays', () => {
+  it('should not create sparse arrays', () => {
     const document = {
       components: {
         schemas: {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -74,6 +74,12 @@ const _bundle = (
         }
 
         set(bundledObj, inventoryPath, bundled$Ref);
+        const parentObj =
+          inventoryPath.length === 1 ? bundledObj : get(bundledObj, inventoryPath.slice(0, inventoryPath.length - 1));
+        if (Array.isArray(parentObj)) {
+          ensureNoSparseArray(parentObj);
+        }
+
         if (!stack[$ref]) {
           stack[$ref] = true;
           _bundle(document, path, stack, bundled$Ref, bundledRefInventory, bundledObj, errorsObj);
@@ -91,3 +97,13 @@ const _bundle = (
 
   return objectToBundle;
 };
+
+function ensureNoSparseArray(arr: unknown[]) {
+  for (let i = 0; i < arr.length; i++) {
+    if (!(i in arr)) {
+      arr[i] = null;
+    }
+  }
+
+  return arr;
+}


### PR DESCRIPTION
Addresses https://github.com/stoplightio/platform-internal/issues/4548

![image](https://user-images.githubusercontent.com/9273484/100234837-52ddbb00-2f34-11eb-9fe8-386383c30698.png)

Re-posting my explanation from Slack:

> It turned out `bundleTarget` in @stoplight/json creates sparse arrays and lodash or some other crap elements (or sth else) uses under the hood does not clone the array correctly.

