### PR TITLE
feat: implement resolveInlineRef util

### DIFF
--- a/src/__tests__/resolveInlineRef.spec.ts
+++ b/src/__tests__/resolveInlineRef.spec.ts
@@ -53,7 +53,7 @@ describe('resolveInlineRef', () => {
     };
 
     expect(resolveInlineRef(doc, '#/a')).toEqual({
-      $ref: '#/b',
+      $ref: '#/a',
     });
   });
 
@@ -79,7 +79,7 @@ describe('resolveInlineRef', () => {
     };
 
     expect(resolveInlineRef(doc, '#/a')).toEqual({
-      $ref: '#/b/foo',
+      $ref: '#/a',
     });
   });
 

--- a/src/__tests__/resolveInlineRef.spec.ts
+++ b/src/__tests__/resolveInlineRef.spec.ts
@@ -20,6 +20,28 @@ describe('resolveInlineRef', () => {
     expect(resolveInlineRef(doc, '#/a')).toEqual('woo!');
   });
 
+  test('should follow refs #2', () => {
+    const doc = {
+      a: {
+        $ref: '#/b/foo',
+      },
+      b: {
+        foo: {
+          $ref: '#/c',
+        },
+        bar: {
+          $ref: '#/e',
+        },
+      },
+      c: {
+        $ref: '#/b/bar',
+      },
+      e: 'woo!',
+    };
+
+    expect(resolveInlineRef(doc, '#/a')).toEqual('woo!');
+  });
+
   test('should handle direct circular refs', () => {
     const doc = {
       a: {
@@ -57,12 +79,7 @@ describe('resolveInlineRef', () => {
     };
 
     expect(resolveInlineRef(doc, '#/a')).toEqual({
-      bar: {
-        $ref: '#/e',
-      },
-      foo: {
-        $ref: '#/c',
-      },
+      $ref: '#/b/foo',
     });
   });
 

--- a/src/__tests__/resolveInlineRef.spec.ts
+++ b/src/__tests__/resolveInlineRef.spec.ts
@@ -1,0 +1,114 @@
+import { resolveInlineRef } from '../resolveInlineRef';
+
+describe('resolveInlineRef', () => {
+  test('should follow refs', () => {
+    const doc = {
+      a: {
+        $ref: '#/b/foo',
+      },
+      b: {
+        $ref: '#/c',
+      },
+      c: {
+        $ref: '#/d',
+      },
+      d: {
+        foo: 'woo!',
+      },
+    };
+
+    expect(resolveInlineRef(doc, '#/a')).toEqual('woo!');
+  });
+
+  test('should handle direct circular refs', () => {
+    const doc = {
+      a: {
+        $ref: '#/b',
+      },
+      b: {
+        $ref: '#/a',
+      },
+    };
+
+    expect(resolveInlineRef(doc, '#/a')).toEqual({
+      $ref: '#/b',
+    });
+  });
+
+  test('should handle direct circular refs #2', () => {
+    const doc = {
+      a: {
+        $ref: '#/b/foo',
+      },
+      b: {
+        foo: {
+          $ref: '#/c',
+        },
+        bar: {
+          $ref: '#/e',
+        },
+      },
+      c: {
+        $ref: '#/b/bar',
+      },
+      e: {
+        $ref: '#/a',
+      },
+    };
+
+    expect(resolveInlineRef(doc, '#/a')).toEqual({
+      bar: {
+        $ref: '#/e',
+      },
+      foo: {
+        $ref: '#/c',
+      },
+    });
+  });
+
+  test('given external reference, should throw', () => {
+    const doc = {
+      a: {
+        $ref: './foo#/b/foo',
+      },
+    };
+
+    expect(resolveInlineRef.bind(null, doc, '#/a')).toThrowError('Cannot resolve external references');
+  });
+
+  test('given missing segment, should throw', () => {
+    const doc = {
+      a: {
+        $ref: '#/b/foo',
+      },
+      b: {
+        bar: false,
+      },
+    };
+
+    expect(resolveInlineRef.bind(null, doc, '#/a')).toThrowError("Could not resolve '#/b/foo'");
+  });
+
+  test('given path pointing at invalid data, should throw', () => {
+    const doc = {
+      a: {
+        $ref: '#/b/foo/bar',
+      },
+      b: {
+        foo: null,
+      },
+    };
+
+    expect(resolveInlineRef.bind(null, doc, '#/a')).toThrowError("Could not resolve '#/b/foo/bar'");
+  });
+
+  test('given invalid $ref type, should throw', () => {
+    const doc = {
+      a: {
+        $ref: 2,
+      },
+    };
+
+    expect(resolveInlineRef.bind(null, doc, '#/a')).toThrowError('$ref should be a string');
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export * from './parseWithPointers';
 export * from './pathToPointer';
 export * from './pointerToPath';
 export * from './renameObjectKey';
+export * from './resolveInlineRef';
 export * from './safeParse';
 export * from './safeStringify';
 export * from './startsWith';

--- a/src/resolveInlineRef.ts
+++ b/src/resolveInlineRef.ts
@@ -21,14 +21,14 @@ function _resolveInlineRef(document: Dictionary<unknown>, ref: string, seen: Set
 
     value = value[segment];
 
-    if (seen.has(value)) {
-      // circular, let's stop
-      return value;
-    }
-
-    seen.add(value);
-
     if (isObject(value) && '$ref' in value) {
+      if (seen.has(value)) {
+        // circular, let's stop
+        return value;
+      }
+
+      seen.add(value);
+
       if (typeof value.$ref !== 'string') {
         throw new TypeError('$ref should be a string');
       }

--- a/src/resolveInlineRef.ts
+++ b/src/resolveInlineRef.ts
@@ -6,7 +6,7 @@ function isObject(maybeObj: unknown): maybeObj is { [key in PropertyKey]: unknow
   return typeof maybeObj === 'object' && maybeObj !== null;
 }
 
-function _resolveInlineRef(document: Dictionary<unknown>, ref: string, seen: Set<unknown>): unknown {
+function _resolveInlineRef(document: Dictionary<unknown>, ref: string, seen: unknown[]): unknown {
   const source = extractSourceFromRef(ref);
   if (source !== null) {
     throw new ReferenceError('Cannot resolve external references');
@@ -22,12 +22,12 @@ function _resolveInlineRef(document: Dictionary<unknown>, ref: string, seen: Set
     value = value[segment];
 
     if (isObject(value) && '$ref' in value) {
-      if (seen.has(value)) {
+      if (seen.includes(value)) {
         // circular, let's stop
-        return value;
+        return seen[seen.length - 1];
       }
 
-      seen.add(value);
+      seen.push(value);
 
       if (typeof value.$ref !== 'string') {
         throw new TypeError('$ref should be a string');
@@ -41,5 +41,5 @@ function _resolveInlineRef(document: Dictionary<unknown>, ref: string, seen: Set
 }
 
 export function resolveInlineRef(document: Dictionary<unknown>, ref: string): unknown {
-  return _resolveInlineRef(document, ref, new Set());
+  return _resolveInlineRef(document, ref, []);
 }

--- a/src/resolveInlineRef.ts
+++ b/src/resolveInlineRef.ts
@@ -1,0 +1,45 @@
+import { Dictionary } from '@stoplight/types';
+import { extractSourceFromRef } from './extractSourceFromRef';
+import { pointerToPath } from './pointerToPath';
+
+function isObject(maybeObj: unknown): maybeObj is { [key in PropertyKey]: unknown } {
+  return typeof maybeObj === 'object' && maybeObj !== null;
+}
+
+function _resolveInlineRef(document: Dictionary<unknown>, ref: string, seen: Set<unknown>): unknown {
+  const source = extractSourceFromRef(ref);
+  if (source !== null) {
+    throw new ReferenceError('Cannot resolve external references');
+  }
+
+  const path = pointerToPath(ref);
+  let value: unknown = document;
+  for (const segment of path) {
+    if (!isObject(value) || !(segment in value)) {
+      throw new ReferenceError(`Could not resolve '${ref}'`);
+    }
+
+    value = value[segment];
+
+    if (seen.has(value)) {
+      // circular, let's stop
+      return value;
+    }
+
+    seen.add(value);
+
+    if (isObject(value) && '$ref' in value) {
+      if (typeof value.$ref !== 'string') {
+        throw new TypeError('$ref should be a string');
+      }
+
+      value = _resolveInlineRef(document, value.$ref, seen);
+    }
+  }
+
+  return value;
+}
+
+export function resolveInlineRef(document: Dictionary<unknown>, ref: string): unknown {
+  return _resolveInlineRef(document, ref, new Set());
+}


### PR DESCRIPTION
While working on https://github.com/stoplightio/platform-internal/issues/4548, I realized JSV (as well as platform and elements) do not follow $refs correctly. This is not an issue at the moment due to the nature of bundled format, but may become one at some point.