### PR TITLE
fix: getLocationForJsonPath should handle incomplete property pair

### DIFF
--- a/src/__tests__/getLocationForJsonPath.spec.ts
+++ b/src/__tests__/getLocationForJsonPath.spec.ts
@@ -179,4 +179,37 @@ describe('getLocationForJsonPath', () => {
       );
     });
   });
+
+  describe('incomplete property pair', () => {
+    const result = parseWithPointers(`{
+ "foo": {
+   "bar": {
+     "baz",
+   }
+ }
+}`);
+
+    test.each`
+      start      | end       | path                                 | closest
+      ${[2, 10]} | ${[4, 4]} | ${['foo', 'bar', 'baz', 'baz-inga']} | ${true}
+      ${[]}      | ${[]}     | ${['foo', 'bar', 'baz', 'baz-inga']} | ${false}
+    `('should return proper location for given JSONPath $path', ({ start, end, path, closest }) => {
+      expect(getLocationForJsonPath(result, path, closest)).toEqual(
+        start.length > 0 && end.length > 0
+          ? {
+              range: {
+                start: {
+                  character: start[1],
+                  line: start[0],
+                },
+                end: {
+                  character: end[1],
+                  line: end[0],
+                },
+              },
+            }
+          : void 0,
+      );
+    });
+  });
 });

--- a/src/getLocationForJsonPath.ts
+++ b/src/getLocationForJsonPath.ts
@@ -25,7 +25,11 @@ function findNodeAtPath(node: IJsonASTNode, path: JsonPath, closest: boolean): I
       }
 
       for (const propertyNode of node.children) {
-        if (Array.isArray(propertyNode.children) && propertyNode.children[0].value === String(segment)) {
+        if (
+          Array.isArray(propertyNode.children) &&
+          propertyNode.children[0].value === String(segment) &&
+          propertyNode.children.length === 2
+        ) {
           node = propertyNode.children[1];
           continue pathLoop;
         }


### PR DESCRIPTION
Needed for https://github.com/stoplightio/platform-internal/issues/5413