### PR TITLE
feat: resolveInlineRef should support summary and description override

### DIFF
--- a/src/__tests__/resolveInlineRef.spec.ts
+++ b/src/__tests__/resolveInlineRef.spec.ts
@@ -128,4 +128,58 @@ describe('resolveInlineRef', () => {
 
     expect(resolveInlineRef.bind(null, doc, '#/a')).toThrowError('$ref should be a string');
   });
+
+  describe('OAS compatibility', () => {
+    test('should override summary and description fields', () => {
+      const doc = {
+        type: 'object',
+        properties: {
+          caves: {
+            type: 'array',
+            contains: {
+              summary: 'Bear cave',
+              $ref: '#/$defs/Cave',
+              description: 'Apparently Tom likes bears',
+            },
+          },
+          greatestBear: {
+            $ref: '#/$defs/Bear',
+            description: 'The greatest bear!',
+          },
+          bestBear: {
+            $ref: '#/$defs/Bear',
+            summary: 'The best bear!',
+          },
+        },
+        $defs: {
+          Bear: {
+            type: 'string',
+            summary: "Tom's favorite bear",
+          },
+          Cave: {
+            type: 'string',
+            summary: 'A cave',
+            description: '_Everyone_ ~hates~ loves caves',
+          },
+        },
+      };
+
+      expect(resolveInlineRef(doc, '#/properties/caves/contains')).toStrictEqual({
+        type: 'string',
+        summary: 'Bear cave',
+        description: 'Apparently Tom likes bears',
+      });
+
+      expect(resolveInlineRef(doc, '#/properties/greatestBear')).toStrictEqual({
+        type: 'string',
+        description: 'The greatest bear!',
+        summary: "Tom's favorite bear",
+      });
+
+      expect(resolveInlineRef(doc, '#/properties/bestBear')).toStrictEqual({
+        type: 'string',
+        summary: 'The best bear!',
+      });
+    });
+  });
 });

--- a/src/resolveInlineRef.ts
+++ b/src/resolveInlineRef.ts
@@ -37,6 +37,20 @@ function _resolveInlineRef(document: Dictionary<unknown>, ref: string, seen: unk
     }
   }
 
+  if (seen.length === 0) {
+    return value;
+  }
+
+  const sourceDocument = seen[seen.length - 1];
+
+  if (isObject(sourceDocument) && ('summary' in sourceDocument || 'description' in sourceDocument)) {
+    return {
+      ...value,
+      ...('description' in sourceDocument ? { description: sourceDocument.description } : null),
+      ...('summary' in sourceDocument ? { summary: sourceDocument.summary } : null),
+    };
+  }
+
   return value;
 }
 


### PR DESCRIPTION
I reminded myself about this case when working on https://github.com/stoplightio/platform-internal/issues/5879.
Initially, we only took json-schema-ref-parser into the account and forgot we also cope with local $refs, some of which are authored by user and therefore not touched by json-schema-ref-parser at all. The handling of such $refs is essential.

The list of affected areas include `@stoplight/http-spec`, `@stoplight/json-schema-tree`, Studio and possibly platform-internal (export).
It shouldn't be a breaking change for any of the aforementioned projects, but I'm not fully certain in case of the export, so I encourage @stoplightio/platinum-falcons to participate in the review.
