### PR TITLE
fix: local refs should not contain any whitespace characters

### DIFF
--- a/src/__tests__/isLocalRef.spec.ts
+++ b/src/__tests__/isLocalRef.spec.ts
@@ -14,6 +14,7 @@ describe('isLocalRef', () => {
     '#/k%22l',
     '#/%20',
     '#/m~0n',
+    '#./d~8z',
   ])('should treat %s as local reference', ref => {
     expect(isLocalRef(ref)).toEqual(true);
   });

--- a/src/__tests__/isLocalRef.spec.ts
+++ b/src/__tests__/isLocalRef.spec.ts
@@ -5,7 +5,21 @@ describe('isLocalRef', () => {
     expect(isLocalRef(ref)).toEqual(true);
   });
 
-  it.each(['', '../#', 'http://a#', '/foo/#', '../test.yaml#/'])('should not treat %s as local reference', ref => {
-    expect(isLocalRef(ref)).toEqual(false);
+  it.each([
+    '',
+    '../#',
+    'http://a#',
+    '/foo/#',
+    '../test.yaml#/',
+    '#/foo\n/bar',
+    '#foo\t/bar',
+    '#foo\u2006​/bar',
+    ' #foo/bar',
+    '#foo /bar',
+    '#/foo/bar ',
+    '# Hello, world!',
+    'foo',
+  ])('should not treat %s as local reference', ref => {
+    expect(isLocalRef(ref as string)).toEqual(false);
   });
 });

--- a/src/__tests__/isLocalRef.spec.ts
+++ b/src/__tests__/isLocalRef.spec.ts
@@ -1,7 +1,20 @@
 import { isLocalRef } from '../isLocalRef';
 
 describe('isLocalRef', () => {
-  it.each(['#', '#/', '#/foo', '#/0/1', '#/~1'])('should treat %s as local reference', ref => {
+  it.each([
+    '#',
+    '#/foo',
+    '#/foo/0',
+    '#/',
+    '#/a~1b',
+    '#/c%25d',
+    '#/e%5Ef',
+    '#/g%7Ch',
+    '#/i%5Cj',
+    '#/k%22l',
+    '#/%20',
+    '#/m~0n',
+  ])('should treat %s as local reference', ref => {
     expect(isLocalRef(ref)).toEqual(true);
   });
 
@@ -12,10 +25,10 @@ describe('isLocalRef', () => {
     '/foo/#',
     '../test.yaml#/',
     '#/foo\n/bar',
-    '#foo\t/bar',
-    '#foo\u2006​/bar',
-    ' #foo/bar',
-    '#foo /bar',
+    '#/foo\t/bar',
+    '#/foo\u2006​/bar',
+    ' #/foo/bar',
+    '#/foo /bar',
     '#/foo/bar ',
     '# Hello, world!',
     'foo',

--- a/src/isLocalRef.ts
+++ b/src/isLocalRef.ts
@@ -1,1 +1,1 @@
-export const isLocalRef = (pointer: string) => pointer.length > 0 && pointer[0] === '#';
+export const isLocalRef = (pointer: string) => pointer.length > 0 && /^#\/?\S*$/.test(pointer);

--- a/src/isLocalRef.ts
+++ b/src/isLocalRef.ts
@@ -1,1 +1,1 @@
-export const isLocalRef = (pointer: string) => pointer.length > 0 && (pointer === '#' || /^#\/\S*$/.test(pointer));
+export const isLocalRef = (pointer: string) => pointer.length > 0 && (pointer === '#' || /^#\S*$/.test(pointer));

--- a/src/isLocalRef.ts
+++ b/src/isLocalRef.ts
@@ -1,1 +1,1 @@
-export const isLocalRef = (pointer: string) => pointer.length > 0 && /^#\/?\S*$/.test(pointer);
+export const isLocalRef = (pointer: string) => pointer.length > 0 && (pointer === '#' || /^#\/\S*$/.test(pointer));


### PR DESCRIPTION
Sometimes markdown strings can be treated as a valid JSON pointer by the `isLocalRef` method. I decided to go with a very simple regex `^#\S*$` which will make sure that string starts from `#` and does not contain any whitespace characters in it since they're not allowed by https://datatracker.ietf.org/doc/html/rfc6901 in JSON pointers.