### PR TITLE
feat: added option to `bundleTarget` to prevent deep clone of document

### DIFF
--- a/src/__tests__/bundle.spec.ts
+++ b/src/__tests__/bundle.spec.ts
@@ -63,6 +63,61 @@ describe('bundleTargetPath()', () => {
     });
   });
 
+  it('should operate on original object if `cloneDocument` set to false', () => {
+    const document = {
+      definitions: {
+        user: {
+          id: 'foo',
+          address: {
+            $ref: '#/definitions/address',
+          },
+        },
+        address: {
+          street: 'foo',
+          user: {
+            $ref: '#/definitions/user',
+          },
+        },
+        card: {
+          zip: '20815',
+        },
+      },
+      __target__: {
+        entity: {
+          $ref: '#/definitions/user',
+        },
+      },
+    };
+
+    const result = bundleTarget({
+      document,
+      path: '#/__target__',
+      cloneDocument: false,
+    });
+
+    expect(document.__target__).toStrictEqual(result);
+
+    expect(result).toEqual({
+      entity: {
+        $ref: `#/${BUNDLE_ROOT}/user`,
+      },
+      [BUNDLE_ROOT]: {
+        user: {
+          id: 'foo',
+          address: {
+            $ref: `#/${BUNDLE_ROOT}/address`,
+          },
+        },
+        address: {
+          street: 'foo',
+          user: {
+            $ref: `#/${BUNDLE_ROOT}/user`,
+          },
+        },
+      },
+    });
+  });
+
   it('should include falsy values', () => {
     const document = {
       definitions: {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -17,14 +17,16 @@ export const bundleTarget = <T = unknown>(
     path,
     bundleRoot = BUNDLE_ROOT,
     errorsRoot = ERRORS_ROOT,
-  }: { document: T; path: string; bundleRoot?: string; errorsRoot?: string },
+    cloneDocument = true,
+  }: { document: T; path: string; bundleRoot?: string; errorsRoot?: string; cloneDocument?: boolean; },
   cur?: unknown,
 ) => {
   if (path === bundleRoot || path === errorsRoot) {
     throw new Error(`Roots do not make any sense`);
   }
 
-  return bundle(cloneDeep(document), pointerToPath(bundleRoot), pointerToPath(errorsRoot))(path, { [path]: true }, cur);
+  const workingDocument = cloneDocument ? cloneDeep(document) : document;
+  return bundle(workingDocument, pointerToPath(bundleRoot), pointerToPath(errorsRoot))(path, { [path]: true }, cur);
 };
 
 const bundle = (document: unknown, bundleRoot: JsonPath, errorsRoot: JsonPath) => {

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -18,7 +18,7 @@ export const bundleTarget = <T = unknown>(
     bundleRoot = BUNDLE_ROOT,
     errorsRoot = ERRORS_ROOT,
     cloneDocument = true,
-  }: { document: T; path: string; bundleRoot?: string; errorsRoot?: string; cloneDocument?: boolean; },
+  }: { document: T; path: string; bundleRoot?: string; errorsRoot?: string; cloneDocument?: boolean },
   cur?: unknown,
 ) => {
   if (path === bundleRoot || path === errorsRoot) {


### PR DESCRIPTION
This is needed to fix performance penalty introduced in `prism-cli` around version 3.2 which uses `bundleTarget` pretty often introducing huge performance overhead on huge documents: https://github.com/stoplightio/prism/issues/1860