### PR TITLE
fix: upgrade node version for release step in circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
 
   release:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:16
     steps:
       - checkout
       - run: yarn


### PR DESCRIPTION
release step in circle ci is failing due to circle ci using old version of node.
