### PR TITLE
fix(bundleTarget): improve # $ref handling, and preserve circular indirect $refs

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -72,6 +72,10 @@ const bundle = (document: unknown, bundleRoot: JsonPath, errorsRoot: JsonPath, k
         const $ref = parent.$ref;
         if (errorsObj[$ref]) return;
 
+        if ($ref === path) {
+          bundledRefInventory[$ref] = '#';
+        }
+
         if (bundledRefInventory[$ref]) {
           parent.$ref = bundledRefInventory[$ref];
 
@@ -122,10 +126,14 @@ const bundle = (document: unknown, bundleRoot: JsonPath, errorsRoot: JsonPath, k
 
         let bundled$Ref: unknown;
         if (typeof document === 'object' && document !== null) {
-          try {
-            bundled$Ref = resolveInlineRef(Object(document), $ref);
-          } catch {
-            bundled$Ref = get(document, _path);
+          // check the simple way first, to preserve these relationships when possible
+          bundled$Ref = get(document, _path);
+
+          if (!bundled$Ref) {
+            try {
+              // if we could not find it with a simple lookup, check for deep refs etc via resolveInlineRef
+              bundled$Ref = resolveInlineRef(Object(document), $ref);
+            } catch {}
           }
         }
 


### PR DESCRIPTION
See tests.

Also switches traverse to use `onEnter` rather than `onProperty` to improve performance. This change created quite the diff because it changed the indentation. To see what actually changed (besides using onEnter), check out the first commit -> https://github.com/stoplightio/json/pull/115/commits/532363e159ef9b5c629911b9b8bf07f951fcbc10#diff-93630daa95fd526fa4d642441d8e9baf528afa37551ca9b78a44b480f342c29c.