### PR TITLE
fix: documents that include # as a ref

### DIFF
--- a/src/__tests__/bundle.spec.ts
+++ b/src/__tests__/bundle.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable simple-import-sort/imports */
 import { cloneDeep, get as _get } from 'lodash';
 
 import { BUNDLE_ROOT as BUNDLE_ROOT_POINTER, bundleTarget } from '../bundle';
@@ -1619,4 +1620,43 @@ describe('bundleTargetPath()', () => {
       ).not.toThrow();
     });
   });
+
+});
+
+it('whole document refs within a document are broken', () => {
+  const petStore = {
+    openapi: '3.0.0',
+    info: {
+      version: '1.0.0',
+      title: 'Swagger Petstore',
+      description:
+        'A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification',
+      termsOfService: 'http://swagger.io/terms/',
+      contact: {
+        name: 'Swagger API Team',
+        email: 'apiteam@swagger.io',
+        url: 'http://swagger.io',
+      },
+      license: {
+        url: 'https://www.apache.org/licenses/LICENSE-2.0.html',
+        name: 'Apache 2.0',
+      },
+    },
+    servers: [
+      {
+        url: 'http://petstore.swagger.io/api',
+      },
+    ],
+    paths: {
+    },
+    components: {
+      schemas: {
+        Pet: {
+          "$ref": "#",
+        },
+      },
+    },
+  };
+  
+  console.log(JSON.stringify(bundleTarget({ document: petStore, path: '#/components'}), null, 4));
 });

--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -70,6 +70,10 @@ const bundle = (document: unknown, bundleRoot: JsonPath, errorsRoot: JsonPath, k
     traverse(cur ? cur : objectToBundle, {
       onEnter: ({ value: parent }) => {
         if (hasRef(parent) && isLocalRef(parent.$ref)) {
+          if (parent.$ref === '#') {
+            throw new Error('it is never OK to reference the document itself from within the document');
+          }
+
           const $ref = parent.$ref;
           if (errorsObj[$ref]) return;
 

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -14,6 +14,11 @@ type Hooks = {
 };
 
 const _traverse = (obj: object, hooks: Partial<Hooks>, path: JsonPath) => {
+  // @ts-ignore
+  // if (obj?.$ref === '#') {
+  //   return;
+  // }
+
   const ctx = { value: obj, path };
 
   if (hooks.onEnter) {


### PR DESCRIPTION
based on api-design outage, starting with PCRecruiter-supplied example OpenAPI document

`"$ref": "#"` is our kryptonite.

see https://stoplight-internal.slack.com/archives/CUBL8DMRP/p1675872847844529
