### PR TITLE
fix: invalid local pointers containing whitespaces are treated as external by resolveInlineRef

### DIFF
--- a/src/__tests__/resolveInlineRef.spec.ts
+++ b/src/__tests__/resolveInlineRef.spec.ts
@@ -137,7 +137,7 @@ describe('resolveInlineRef', () => {
 
   it('should resolve top-level $ref', () => {
     const doc = {
-      $ref: '#/$defs/User',
+      $ref: '#/%24defs/User',
       $defs: {
         User: {
           type: 'object',
@@ -169,16 +169,16 @@ describe('resolveInlineRef', () => {
             type: 'array',
             contains: {
               summary: 'Bear cave',
-              $ref: '#/$defs/Cave',
+              $ref: '#/%24defs/Cave',
               description: 'Apparently Tom likes bears',
             },
           },
           greatestBear: {
-            $ref: '#/$defs/Bear',
+            $ref: '#/%24defs/Bear',
             description: 'The greatest bear!',
           },
           bestBear: {
-            $ref: '#/$defs/Bear',
+            $ref: '#/%24defs/Bear',
             summary: 'The best bear!',
           },
         },
@@ -221,6 +221,48 @@ describe('resolveInlineRef', () => {
         summary: 'The best bear!',
       });
       expect(resolveInlineRefWithLocation(doc, '#/properties/bestBear')).toHaveProperty('location', ['$defs', 'Bear']);
+    });
+  });
+
+  it('handles encoded characters', () => {
+    const doc = {
+      type: 'object',
+      $defs: {
+        'Cool Bear': {
+          type: 'string',
+        },
+        'самый крутой медведь?': {
+          const: 'винни пух)',
+        },
+      },
+    };
+
+    expect(resolveInlineRef(doc, '#/%24defs/Cool%20Bear')).toStrictEqual({
+      type: 'string',
+    });
+
+    expect(
+      resolveInlineRef(
+        doc,
+        '#/%24defs/%D1%81%D0%B0%D0%BC%D1%8B%D0%B9%20%D0%BA%D1%80%D1%83%D1%82%D0%BE%D0%B9%20%D0%BC%D0%B5%D0%B4%D0%B2%D0%B5%D0%B4%D1%8C%3F',
+      ),
+    ).toStrictEqual({
+      const: 'винни пух)',
+    });
+  });
+
+  it('gracefully handles unencoded characters', () => {
+    const doc = {
+      type: 'object',
+      $defs: {
+        'Cool Bear': {
+          type: 'string',
+        },
+      },
+    };
+
+    expect(resolveInlineRef(doc, '#/$defs/Cool Bear')).toStrictEqual({
+      type: 'string',
     });
   });
 });

--- a/src/extractSourceFromRef.ts
+++ b/src/extractSourceFromRef.ts
@@ -1,7 +1,7 @@
-import { isLocalRef } from './isLocalRef';
+import { isExternalRef } from './isExternalRef';
 
 export const extractSourceFromRef = (ref: unknown): string | null => {
-  if (typeof ref !== 'string' || ref.length === 0 || isLocalRef(ref)) {
+  if (typeof ref !== 'string' || ref.length === 0 || !isExternalRef(ref)) {
     return null;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export * from './getJsonPathForPosition';
 export * from './getLastPathSegment';
 export * from './getLocationForJsonPath';
 export * from './hasRef';
+export * from './isExternalRef';
 export * from './isLocalRef';
 export * from './isPlainObject';
 export * from './parseWithPointers';

--- a/src/isExternalRef.ts
+++ b/src/isExternalRef.ts
@@ -1,0 +1,1 @@
+export const isExternalRef = (pointer: string) => pointer.length > 0 && pointer[0] !== '#';


### PR DESCRIPTION
This fixes an e2e issue in https://github.com/stoplightio/platform-internal/pull/16345 
it's extracted out of a bigger PR #122 