### PR TITLE
fix: ensure value preserved for ref siblings

### DIFF
--- a/src/__tests__/resolveExternalRef.spec.ts
+++ b/src/__tests__/resolveExternalRef.spec.ts
@@ -141,4 +141,44 @@ describe('resolveExternalRef', () => {
 
     await expect(resolveExternalRef(inventory, 'a', '#')).rejects.toThrowError('$ref should be a string');
   });
+
+  it('the examples should not be changed', async () => {
+    const inventory = {
+      a: {
+        AAAAA: {
+          $ref: 'b#/components/schemas/referenced',
+          description: 'AAAAA',
+          examples: ['AAAAA'],
+        },
+        BBBBB: {
+          $ref: 'b#/components/schemas/referenced',
+          description: 'BBBBB',
+          examples: ['BBBBB'],
+        },
+      },
+      b: {
+        components: {
+          schemas: {
+            referenced: {
+              type: 'string',
+              title: 'referenced',
+            },
+          },
+        },
+      },
+    };
+
+    await expect(resolveExternalRef(inventory, 'a', '#')).resolves.toEqual({
+      AAAAA: {
+        $ref: 'b#/components/schemas/referenced',
+        description: 'AAAAA',
+        examples: ['AAAAA'],
+      },
+      BBBBB: {
+        $ref: 'b#/components/schemas/referenced',
+        description: 'BBBBB',
+        examples: ['BBBBB'],
+      },
+    });
+  });
 });

--- a/src/__tests__/resolveInlineRef.spec.ts
+++ b/src/__tests__/resolveInlineRef.spec.ts
@@ -265,4 +265,73 @@ describe('resolveInlineRef', () => {
       type: 'string',
     });
   });
+
+  it('does not override examples', () => {
+    const doc = {
+      AAAAA: {
+        $ref: '#/components/schemas/Referenced',
+        description: 'AAAAA',
+        examples: ['AAAAA'],
+      },
+      BBBBB: {
+        $ref: '#/components/schemas/Referenced',
+        description: 'BBBBB',
+        examples: ['BBBBB'],
+      },
+      components: {
+        schemas: {
+          Referenced: {
+            description: 'AAAAA',
+            examples: ['AAAAA'],
+            title: 'referenced',
+            type: 'string',
+          },
+        },
+      },
+    };
+    const result = resolveInlineRef(doc, `#/BBBBB`);
+    expect(result).toStrictEqual({
+      type: 'string',
+      description: 'BBBBB',
+      examples: ['BBBBB'],
+      title: 'referenced',
+    });
+  });
+
+  it('description is pulled in from ref if not a ref sibling', () => {
+    const doc = {
+      AAAAA: {
+        $ref: '#/components/schemas/Referenced',
+        examples: ['AAAAA'],
+      },
+      BBBBB: {
+        $ref: '#/components/schemas/Referenced',
+        examples: ['BBBBB'],
+      },
+      components: {
+        schemas: {
+          Referenced: {
+            description: 'AAAAA',
+            examples: ['AAAAA'],
+            title: 'referenced',
+            type: 'string',
+          },
+        },
+      },
+    };
+    let result = resolveInlineRef(doc, `#/AAAAA`);
+    expect(result).toStrictEqual({
+      type: 'string',
+      description: 'AAAAA',
+      examples: ['AAAAA'],
+      title: 'referenced',
+    });
+    result = resolveInlineRef(doc, `#/BBBBB`);
+    expect(result).toStrictEqual({
+      type: 'string',
+      description: 'AAAAA',
+      examples: ['BBBBB'],
+      title: 'referenced',
+    });
+  });
 });

--- a/src/resolvers/utils.ts
+++ b/src/resolvers/utils.ts
@@ -6,7 +6,14 @@ import { isPlainObject } from '../isPlainObject';
 import { assertObjectWithValidRef, assertResolvableInput, hasSomeRef } from './guards';
 
 export function applyOverrides(document: unknown, value: unknown) {
-  if (isPlainObject(value) && isPlainObject(document) && ('summary' in document || 'description' in document)) {
+  if (isPlainObject(value) && isPlainObject(document)) {
+    //update value of unexpected $ref siblings
+    for (const key of Object.keys(value)) {
+      if (key in document) {
+        value[key] = document[key];
+      }
+    }
+    //ensure the value is preserved of expected $ref siblings
     return {
       ...value,
       ...('description' in document ? { description: document.description } : null),


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://github.com/stoplightio/elements/issues/2419

We are override values when we should not be. Json schema only supports ref siblings for description and summary, and technically all other ref siblings should be ignored. Instead of ignoring them entirely, we are overriding them with values from the referenced object. In a way we are ignoring that other siblings existing by overriding them with the new values, but ultimately that is creating a more confusing result for costumers. 

## Description
<!-- Describe your technical changes in detail. -->
If a key in the referenced object matches one from the document, use the document's value. This means we will no longer override a siblings value with a referenced objects value. 

Removed check for `&& ('summary' in document || 'description' in document)` 

I am leaving as is the specific checks for summary and description as those are expected ref siblings and we should always check for them

## How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Did you test the changes locally, in a PR environment, or somewhere else? -->
<!-- Were unit/integration/e2e/other tests added? If not, why? -->
<!-- Also describe how one or more persons giving a code review can verify your changes. -->
Added two unit tests for inline and external refs for the specific scenario of overriding the examples  ref sibling
Added a unit test to ensure description was still working as expected
Ran yarn test locally and all passed

## Screenshot(s)/recordings(s)
<!-- If applicable, add screenshots or gifs to help demonstrate the changes. -->
<!-- If not applicable, remove this screenshots section before creating the PR. -->


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
