### PR TITLE
Fix/stop 184/performance issue

### DIFF
--- a/src/decycle.ts
+++ b/src/decycle.ts
@@ -1,40 +1,41 @@
 import { isPlainObject } from './isPlainObject';
 import { pathToPointer } from './pathToPointer';
 
-export function decycle(obj: unknown, replacer?: (value: any) => any) {
+export const decycle = (obj: unknown, replacer?: (value: any) => any) => {
   const objs = new WeakMap<object, string>();
   const processedObjs = new WeakSet<object>();
-  function derez(value: any, path: (string | number)[]): any {
-    if (replacer) {
-      value = replacer(value);
-    }
+
+  return (function derez(value: any, path: string[]) {
+    // The new object or array
+    let curObj: any;
+
+    // If a replacer function was provided, then call it to get a replacement value.
+    if (replacer) value = replacer(value);
+
     if (isPlainObject(value) || Array.isArray(value)) {
       // The path of an earlier occurance of value
       const oldPath = objs.get(value);
       // If the value is an object or array, look to see if we have already
       // encountered it. If so, return a {"$ref":PATH} object.
-      if (oldPath) {
-        return { $ref: oldPath };
-      }
+      if (oldPath) return { $ref: oldPath };
+
       objs.set(value, pathToPointer(path));
       // If it is an array, replicate the array.
       if (Array.isArray(value)) {
-        return value.map((element, i) => derez(element, [...path, i]));
+        curObj = value.map((element, i) => derez(element, [...path, String(i)]));
+      } else {
+        // It is an object, replicate the object.
+        curObj = {};
+        Object.keys(value).forEach(name => {
+          curObj[name] = derez(value[name], [...path, name]);
+        });
       }
-      const newObj: Record<string, any> = {};
-      for (const name in value) {
-        if (Object.prototype.hasOwnProperty.call(value, name)) {
-          newObj[name] = derez(value[name], [...path, name]);
-        }
-      }
-      // Only delete the object from the map if it has not been processed before
       if (!processedObjs.has(value)) {
         objs.delete(value);
       }
       processedObjs.add(value);
-      return newObj;
+      return curObj;
     }
     return value;
-  }
-  return derez(obj, []);
-}
+  })(obj, []);
+};

--- a/src/decycle.ts
+++ b/src/decycle.ts
@@ -3,39 +3,38 @@ import { pathToPointer } from './pathToPointer';
 
 export function decycle(obj: unknown, replacer?: (value: any) => any) {
   const objs = new WeakMap<object, string>();
+  const processedObjs = new WeakSet<object>();
   function derez(value: any, path: (string | number)[]): any {
     if (replacer) {
       value = replacer(value);
     }
-
     if (isPlainObject(value) || Array.isArray(value)) {
       // The path of an earlier occurance of value
       const oldPath = objs.get(value);
-
       // If the value is an object or array, look to see if we have already
       // encountered it. If so, return a {"$ref":PATH} object.
       if (oldPath) {
         return { $ref: oldPath };
       }
-
       objs.set(value, pathToPointer(path));
       // If it is an array, replicate the array.
       if (Array.isArray(value)) {
         return value.map((element, i) => derez(element, [...path, i]));
       }
-
       const newObj: Record<string, any> = {};
       for (const name in value) {
         if (Object.prototype.hasOwnProperty.call(value, name)) {
           newObj[name] = derez(value[name], [...path, name]);
         }
       }
-      // deleteing object before returing
-      objs.delete(value);
+      // Only delete the object from the map if it has not been processed before
+      if (!processedObjs.has(value)) {
+        objs.delete(value);
+      }
+      processedObjs.add(value);
       return newObj;
     }
     return value;
   }
-
   return derez(obj, []);
 }


### PR DESCRIPTION

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
https://smartbear.atlassian.net/browse/STOP-184

## Description
Performance Issue for decycle spec


## How Has This Been Tested?
1. Locally run test cases using yarn test
2. Tested this changes in PRISM using yalc
3. Tested this changes in SPECTRAL using yalc
4. Tested this changes in PLATFROM_INTERNAL using yalc


## Screenshot(s)/recordings(s)
<img width="1657" alt="Spectral_test" src="https://github.com/user-attachments/assets/c126b13f-341c-48cc-8fd7-2155e0098bc0">
<img width="1582" alt="JSON_test" src="https://github.com/user-attachments/assets/11787d05-0369-4290-9889-8af7d9230c5f">
<img width="1715" alt="Prism_Test" src="https://github.com/user-attachments/assets/b14a9858-b9e8-420c-992b-99bc4d246f75">

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This PR's code follows as closely as possible [the coding style/guidelines of this project](???).
- [ ] I have added error reporting and followed [the error reporting guidelines](???).
- [ ] I have added event tracking and followed [the event tracking guidelines](???).
- [ ] I have updated any relevant documentation accordingly to reflect this PR's changes.
- [ ] I have added automated tests (unit/integration/e2e/other) to cover my changes.
- [ ] All new and existing tests pass locally (excluding flaky CI tests).
<!-- It's up to the discretion of the code reviewer(s) whether or not all of these must be checked before approval. -->
